### PR TITLE
Compatibility fix to get mjpg_streamer work with kernel 3.18

### DIFF
--- a/mjpg-streamer-experimental/plugins/input_uvc/input_uvc.c
+++ b/mjpg-streamer-experimental/plugins/input_uvc/input_uvc.c
@@ -512,10 +512,14 @@ void *cam_thread(void *arg)
         if ((pcontext->videoIn->formatIn == V4L2_PIX_FMT_YUYV) || (pcontext->videoIn->formatIn == V4L2_PIX_FMT_RGB565)) {
             DBG("compressing frame from input: %d\n", (int)pcontext->id);
             pglobal->in[pcontext->id].size = compress_image_to_jpeg(pcontext->videoIn, pglobal->in[pcontext->id].buf, pcontext->videoIn->framesizeIn, gquality);
+            /* copy this frame's timestamp to user space */
+            pglobal->in[pcontext->id].timestamp = pcontext->videoIn->buf.timestamp;
         } else {
         #endif
             DBG("copying frame from input: %d\n", (int)pcontext->id);
-            pglobal->in[pcontext->id].size = memcpy_picture(pglobal->in[pcontext->id].buf, pcontext->videoIn->tmpbuffer, pcontext->videoIn->buf.bytesused);
+            pglobal->in[pcontext->id].size = memcpy_picture(pglobal->in[pcontext->id].buf, pcontext->videoIn->tmpbuffer, pcontext->videoIn->tmpbytesused);
+            /* copy this frame's timestamp to user space */
+            pglobal->in[pcontext->id].timestamp = pcontext->videoIn->tmptimestamp;
         #ifndef NO_LIBJPEG
         }
         #endif
@@ -528,8 +532,6 @@ void *cam_thread(void *arg)
         prev_size = global->size;
 #endif
 
-        /* copy this frame's timestamp to user space */
-        pglobal->in[pcontext->id].timestamp = pcontext->videoIn->buf.timestamp;
 
         /* signal fresh_frame */
         pthread_cond_broadcast(&pglobal->in[pcontext->id].db_update);

--- a/mjpg-streamer-experimental/plugins/input_uvc/v4l2uvc.c
+++ b/mjpg-streamer-experimental/plugins/input_uvc/v4l2uvc.c
@@ -497,6 +497,7 @@ int uvcGrab(struct vdIn *vd)
 {
 #define HEADERFRAME1 0xaf
     int ret;
+    int32_t bytesused;
 
     if(vd->streamingState == STREAMING_OFF) {
         if(video_enable(vd))
@@ -511,6 +512,7 @@ int uvcGrab(struct vdIn *vd)
         perror("Unable to dequeue buffer");
         goto err;
     }
+    bytesused = vd->buf.bytesused;
 
     switch(vd->formatIn) {
     case V4L2_PIX_FMT_MJPEG:
@@ -529,6 +531,8 @@ int uvcGrab(struct vdIn *vd)
         */
 
         memcpy(vd->tmpbuffer, vd->mem[vd->buf.index], vd->buf.bytesused);
+        vd->tmpbytesused = vd->buf.bytesused;
+        vd->tmptimestamp = vd->buf.timestamp;
 
         if(debug)
             fprintf(stderr, "bytes in used %d \n", vd->buf.bytesused);
@@ -547,6 +551,7 @@ int uvcGrab(struct vdIn *vd)
     }
 
     ret = xioctl(vd->fd, VIDIOC_QBUF, &vd->buf);
+    vd->buf.bytesused = bytesused;
     if(ret < 0) {
         perror("Unable to requeue buffer");
         goto err;

--- a/mjpg-streamer-experimental/plugins/input_uvc/v4l2uvc.h
+++ b/mjpg-streamer-experimental/plugins/input_uvc/v4l2uvc.h
@@ -28,6 +28,7 @@
 
 
 #include <stdio.h>
+#include <stdint.h>
 #include <string.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -108,6 +109,8 @@ struct vdIn {
     int framecount;
     int recordstart;
     int recordtime;
+    uint32_t tmpbytesused;
+    struct timeval tmptimestamp;
     v4l2_std_id vstd;
     unsigned long frame_period_time; // in ms
     unsigned char soft_framedrop;


### PR DESCRIPTION
Patches taken from

* http://www.raspberrypi.org/forums/viewtopic.php?f=28&t=97983#p686333
* http://www.raspberrypi.org/forums/viewtopic.php?f=28&t=97983#p686670

and adapter to current source. All credit for the actual fix goes to
"koos" on the Raspberry Pi forums.