### PR TITLE
Permit rtsp plujgin to compile

### DIFF
--- a/mjpg-streamer-experimental/plugins/output_rtsp/output_rtsp.c
+++ b/mjpg-streamer-experimental/plugins/output_rtsp/output_rtsp.c
@@ -159,7 +159,7 @@ void *worker_thread(void *arg)
 
 
         DBG("waiting for fresh frame\n");
-        pthread_mutex_lock(&pglobal->in[plugin_number].db);
+        pthread_mutex_lock(&pglobal->in[input_number].db);
         pthread_cond_wait(&pglobal->in[input_number].db_update, &pglobal->in[input_number].db);
 
         /* read buffer */


### PR DESCRIPTION
Found the 'fix' on the mjpg-streamer discussion board on how to get rtsp plugin to compile.

http://sourceforge.net/p/mjpg-streamer/discussion/739917/thread/cd362789

Haven't actually tested it yet, but it DOES compile.