### PR TITLE
<mjpg-streamer-experimental/plugins/output_file/output_file.c> Fixed default (base) file path ussues

### DIFF
--- a/mjpg-streamer-experimental/plugins/output_file/output_file.c
+++ b/mjpg-streamer-experimental/plugins/output_file/output_file.c
@@ -307,7 +307,7 @@ void *worker_thread(void *arg)
 
             /*
              * maintain ringbuffer
-             * do not maintain ringbuffer for each picture, this saves ressources since
+             * do not maintain ringbuffer for each picture, this saves resources since
              * each run of the maintainance function involves sorting/malloc/free operations
              */
             if(ringbuffer_exceed <= 0) {

--- a/mjpg-streamer-experimental/plugins/output_file/output_file.c
+++ b/mjpg-streamer-experimental/plugins/output_file/output_file.c
@@ -50,7 +50,7 @@
 static pthread_t worker;
 static globals *pglobal;
 static int fd, delay, ringbuffer_size = -1, ringbuffer_exceed = 0, max_frame_size;
-static char *folder = "/tmp";
+static char *folder = "/";
 static unsigned char *frame = NULL;
 static char *command = NULL;
 static int input_number = 0;


### PR DESCRIPTION
The problem is with default folder setting to tmp/, the user can't really specify another folder without using the wierd format of /tmp/..//*. Fixed this issue by setting the default path to /.