### PR TITLE
Correct make_deb.sh script to use git; don't prepend a letter to pkgversion

### DIFF
--- a/mjpg-streamer-experimental/scripts/make_deb.sh
+++ b/mjpg-streamer-experimental/scripts/make_deb.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
 
-# update via SVN
-svn up
+# update via git
+git pull
 
 # find out the current revision
-SVNVERSION="$(export LANG=C && export LC_ALL=C && echo $(svn info | awk '/^Revision:/ { print $2 }'))"
+GITVERSION="$(export LANG=C && export LC_ALL=C && echo $(git show -s --format=%at-%H))"
 
 # use checkinstall to create the DEB package
 sudo checkinstall -D \
                   --pkgname "mjpg-streamer" \
-                  --pkgversion "r$SVNVERSION" \
+                  --pkgversion "$GITVERSION" \
                   --pkgrelease "1" \
                   --maintainer "tom_stoeveken@users.sourceforge.net" \
                   --requires "libjpeg62" \

--- a/mjpg-streamer-experimental/scripts/make_deb.sh
+++ b/mjpg-streamer-experimental/scripts/make_deb.sh
@@ -6,6 +6,9 @@ git pull
 # find out the current revision
 GITVERSION="$(export LANG=C && export LC_ALL=C && echo $(git show -s --format=%at-%H))"
 
+# run cmake before our checkinstall run
+cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr .
+
 # use checkinstall to create the DEB package
 sudo checkinstall -D \
                   --pkgname "mjpg-streamer" \


### PR DESCRIPTION
Just a tiny convenience edit I made since I'm about to deploy this to multiple Raspberry Pi's. Changes the use of SVN to Git instead, and removed the "r" that was prepended to the --pkgversion argument (which makes sense from an SVN standpoint I guess, but isn't a valid way to start a debian package version string!).

Admittedly the --maintainer should probably be changed too, but I figure the first step is to have this script actually work in the first place ;)