### PR TITLE
A docker image for mjpg-streamer

### DIFF
--- a/mjpg-streamer-experimental/Dockerfile
+++ b/mjpg-streamer-experimental/Dockerfile
@@ -1,0 +1,56 @@
+FROM ubuntu:16.04
+
+# Install all necessary packages for OpenCV
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y wget unzip git build-essential cmake pkg-config \
+            libjpeg8-dev libtiff5-dev libjasper-dev libpng12-dev \
+            libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
+            libxvidcore-dev libx264-dev \
+            libgtk-3-dev \
+            libatlas-base-dev gfortran \
+            python3.5-dev
+
+WORKDIR /code
+
+# Configure python
+RUN wget -q https://bootstrap.pypa.io/get-pip.py \
+    && python get-pip.py
+RUN pip install numpy
+
+# Download and build OpenCV source code
+RUN wget -q -O opencv.zip https://github.com/opencv/opencv/archive/3.2.0.zip \  
+    && wget -q -O opencv_contrib.zip https://github.com/opencv/opencv_contrib/archive/3.2.0.zip
+RUN unzip opencv.zip \
+    && unzip opencv_contrib.zip
+RUN cd opencv-3.2.0 \
+    && mkdir build \
+    && cd build \
+    && cmake -D CMAKE_BUILD_TYPE=RELEASE \
+        -D CMAKE_INSTALL_PREFIX=/usr/local \
+        -D INSTALL_PYTHON_EXAMPLES=ON \
+        -D INSTALL_C_EXAMPLES=OFF \
+        -D OPENCV_EXTRA_MODULES_PATH=/code/opencv_contrib-3.2.0/modules \
+        -D PYTHON_EXECUTABLE=/usr/bin/python3.5
+        -D BUILD_EXAMPLES=ON .. \
+    && make -j4 \
+    && make install && ldconfig
+RUN cd /code \
+    && rm -rf opencv-3.2.0 opencv_contrib-3.2.0 opencv.zip opencv_contrib.zip get-pip.py
+
+# Build mjpg_streamer
+# Need to run container with the device: docker run -t -i -p 8080:8080/tcp --device=/dev/video0 image:tag "-i input_opencv.so"
+RUN git clone https://github.com/chunliu/mjpg-streamer.git 
+
+WORKDIR mjpg-streamer/mjpg-streamer-experimental
+
+RUN make \ 
+    && make install \
+
+EXPOSE 8080/TCP
+
+ENTRYPOINT ["docker-start.sh", "-o output_http.so -w ./www"]
+
+CMD ["-i input_uvc.so"]
+
+# To use OpenCV input: 
+# CMD ["mjpg_streamer", "-o output_http.so -w ./www", "-i input_opencv.so"]

--- a/mjpg-streamer-experimental/Dockerfile
+++ b/mjpg-streamer-experimental/Dockerfile
@@ -1,7 +1,10 @@
 FROM chunliu/docker-opencv
 
+MAINTAINER Chun Liu <https://github.com/chunliu>
+LABEL Description="A Docker image for mjpg_streamer." Version="0.3"
+
 # Build mjpg_streamer
-# Need to run container with the device: docker run -t -i -p 8080:8080/tcp --device=/dev/video0 image:tag "-i input_opencv.so"
+# Need to run container with the device: docker run -t -i -p 8080:8080/tcp --device=/dev/video0 image:tag
 RUN git clone https://github.com/chunliu/mjpg-streamer.git 
 
 WORKDIR /mjpg-streamer/mjpg-streamer-experimental

--- a/mjpg-streamer-experimental/Dockerfile
+++ b/mjpg-streamer-experimental/Dockerfile
@@ -1,56 +1,17 @@
-FROM ubuntu:16.04
-
-# Install all necessary packages for OpenCV
-RUN apt-get update && apt-get upgrade -y \
-    && apt-get install -y wget unzip git build-essential cmake pkg-config \
-            libjpeg8-dev libtiff5-dev libjasper-dev libpng12-dev \
-            libavcodec-dev libavformat-dev libswscale-dev libv4l-dev \
-            libxvidcore-dev libx264-dev \
-            libgtk-3-dev \
-            libatlas-base-dev gfortran \
-            python3.5-dev
-
-WORKDIR /code
-
-# Configure python
-RUN wget -q https://bootstrap.pypa.io/get-pip.py \
-    && python get-pip.py
-RUN pip install numpy
-
-# Download and build OpenCV source code
-RUN wget -q -O opencv.zip https://github.com/opencv/opencv/archive/3.2.0.zip \  
-    && wget -q -O opencv_contrib.zip https://github.com/opencv/opencv_contrib/archive/3.2.0.zip
-RUN unzip opencv.zip \
-    && unzip opencv_contrib.zip
-RUN cd opencv-3.2.0 \
-    && mkdir build \
-    && cd build \
-    && cmake -D CMAKE_BUILD_TYPE=RELEASE \
-        -D CMAKE_INSTALL_PREFIX=/usr/local \
-        -D INSTALL_PYTHON_EXAMPLES=ON \
-        -D INSTALL_C_EXAMPLES=OFF \
-        -D OPENCV_EXTRA_MODULES_PATH=/code/opencv_contrib-3.2.0/modules \
-        -D PYTHON_EXECUTABLE=/usr/bin/python3.5
-        -D BUILD_EXAMPLES=ON .. \
-    && make -j4 \
-    && make install && ldconfig
-RUN cd /code \
-    && rm -rf opencv-3.2.0 opencv_contrib-3.2.0 opencv.zip opencv_contrib.zip get-pip.py
+FROM chunliu/docker-opencv
 
 # Build mjpg_streamer
 # Need to run container with the device: docker run -t -i -p 8080:8080/tcp --device=/dev/video0 image:tag "-i input_opencv.so"
 RUN git clone https://github.com/chunliu/mjpg-streamer.git 
 
-WORKDIR mjpg-streamer/mjpg-streamer-experimental
+WORKDIR /mjpg-streamer/mjpg-streamer-experimental
 
 RUN make \ 
     && make install \
+    && chmod +x docker-start.sh
 
 EXPOSE 8080/TCP
 
-ENTRYPOINT ["docker-start.sh", "-o output_http.so -w ./www"]
+ENTRYPOINT ["/mjpg-streamer/mjpg-streamer-experimental/docker-start.sh", "-o output_http.so -w ./www"]
 
 CMD ["-i input_uvc.so"]
-
-# To use OpenCV input: 
-# CMD ["mjpg_streamer", "-o output_http.so -w ./www", "-i input_opencv.so"]

--- a/mjpg-streamer-experimental/Dockerfile
+++ b/mjpg-streamer-experimental/Dockerfile
@@ -12,6 +12,6 @@ RUN make \
 
 EXPOSE 8080/TCP
 
-ENTRYPOINT ["/mjpg-streamer/mjpg-streamer-experimental/docker-start.sh", "-o output_http.so -w ./www"]
+ENTRYPOINT ["/mjpg-streamer/mjpg-streamer-experimental/docker-start.sh", "output_http.so -w ./www"]
 
-CMD ["-i input_uvc.so"]
+CMD ["input_uvc.so"]

--- a/mjpg-streamer-experimental/docker-start.sh
+++ b/mjpg-streamer-experimental/docker-start.sh
@@ -11,5 +11,5 @@ if [ "$1" = 'postgres' ]; then
     exec gosu postgres "$@"
 fi
 
-export LD_LIBRARY_PATH=.
-./mjpg_streamer "$@" 
+export LD_LIBRARY_PATH="$(pwd)"
+./mjpg_streamer -o "$1" -i "$2"

--- a/mjpg-streamer-experimental/docker-start.sh
+++ b/mjpg-streamer-experimental/docker-start.sh
@@ -11,5 +11,5 @@ if [ "$1" = 'postgres' ]; then
     exec gosu postgres "$@"
 fi
 
-export LD_LIBRARY_PATH="$(pwd)"
+export LD_LIBRARY_PATH="/mjpg-streamer/mjpg-streamer-experimental"
 ./mjpg_streamer -o "$1" -i "$2"

--- a/mjpg-streamer-experimental/docker-start.sh
+++ b/mjpg-streamer-experimental/docker-start.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = 'postgres' ]; then
+    chown -R postgres "$PGDATA"
+
+    if [ -z "$(ls -A "$PGDATA")" ]; then
+        gosu postgres initdb
+    fi
+
+    exec gosu postgres "$@"
+fi
+
+export LD_LIBRARY_PATH=.
+./mjpg_streamer "$@" 

--- a/mjpg-streamer-experimental/docker-start.sh
+++ b/mjpg-streamer-experimental/docker-start.sh
@@ -1,15 +1,5 @@
 #!/bin/sh
 set -e
 
-if [ "$1" = 'postgres' ]; then
-    chown -R postgres "$PGDATA"
-
-    if [ -z "$(ls -A "$PGDATA")" ]; then
-        gosu postgres initdb
-    fi
-
-    exec gosu postgres "$@"
-fi
-
 export LD_LIBRARY_PATH="/mjpg-streamer/mjpg-streamer-experimental"
 ./mjpg_streamer -o "$1" -i "$2"

--- a/mjpg-streamer-experimental/plugins/input_opencv/CMakeLists.txt
+++ b/mjpg-streamer-experimental/plugins/input_opencv/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 # TODO: which components do I need?
-find_package(OpenCV COMPONENTS core imgproc highgui)
+# To fix the error: "undefined symbol: _ZN2cv12VideoCaptureC1Ev"
+find_package(OpenCV COMPONENTS core imgproc highgui videoio)
 
 MJPG_STREAMER_PLUGIN_OPTION(input_opencv "OpenCV input plugin"
                             ONLYIF OpenCV_FOUND)


### PR DESCRIPTION
This request includes the following 3 changes: 

- Include videoio package in plugins/input_opencv/CMakeLists.txt so that the plugin, input_opencv.so, can work properly with OpenCV 3.2.0. 
- A Dockerfile for building a docker image for mjpg-streamer. 
- A bash script served as the entrypoint for the docker image. 