### PR TITLE
Fix an error when loading symbol of numpy in cvfilter_py

### DIFF
--- a/mjpg-streamer-experimental/plugins/input_opencv/input_opencv.cpp
+++ b/mjpg-streamer-experimental/plugins/input_opencv/input_opencv.cpp
@@ -284,7 +284,7 @@ int input_init(input_parameter *param, int plugin_no)
         IPRINT("filter........... : %s\n", filter);
         IPRINT("filter args ..... : %s\n", filter_args);
         
-        pctx->filter_handle = dlopen(filter, RTLD_LAZY);
+        pctx->filter_handle = dlopen(filter, RTLD_LAZY | RTLD_GLOBAL);
         if(!pctx->filter_handle) {
             LOG("ERROR: could not find input plugin\n");
             LOG("       Perhaps you want to adjust the search path with:\n");


### PR DESCRIPTION
# Environment
* Raspberry pi zero W
* `uname -a`:
```
Linux raspberrypi 4.9.59+ #1047 Sun Oct 29 11:47:10 GMT 2017 armv6l GNU/Linux
```
* Python 3.5.3
* numpy 1.13.3

# Description

I got an error with this command:
```
$ ./mjpg_streamer -i "./input_opencv.so --filter ./cvfilter_py.so --fargs hoge.py" -o "./output_http.so -w ./www"
```
and the error message is below,
```
MJPG Streamer Version.: 2.0
 i: device........... : default
 i: Desired Resolution: 640 x 480
 i: filter........... : ./cvfilter_py.so
 i: filter args ..... : hoge.py
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/numpy/core/__init__.py", line 16, in <module>
    from . import multiarray
ImportError: /usr/local/lib/python3.5/dist-packages/numpy/core/multiarray.cpython-35m-arm-linux-gnueabihf.so: undefined symbol: PyExc_SystemError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/numpy/__init__.py", line 142, in <module>
    from . import add_newdocs
  File "/usr/local/lib/python3.5/dist-packages/numpy/add_newdocs.py", line 13, in <module>
    from numpy.lib import add_newdoc
  File "/usr/local/lib/python3.5/dist-packages/numpy/lib/__init__.py", line 8, in <module>
    from .type_check import *
  File "/usr/local/lib/python3.5/dist-packages/numpy/lib/type_check.py", line 11, in <module>
    import numpy.core.numeric as _nx
  File "/usr/local/lib/python3.5/dist-packages/numpy/core/__init__.py", line 26, in <module>
    raise ImportError(msg)
ImportError:
Importing the multiarray numpy extension module failed.  Most
likely you are trying to import a failed build of numpy.
If you're working with a numpy git repo, try `git clean -xdf` (removes all
files not under version control).  Otherwise reinstall numpy.

Original error was: /usr/local/lib/python3.5/dist-packages/numpy/core/multiarray.cpython-35m-arm-linux-gnueabihf.so: undefined symbol: PyExc_SystemError

Error loading numpy!
```
This error is fixed by calling `dlopen()` for `cvfilter_py.so` with `RTLD_GLOBAL` flag.
There is a similar issue in [https://github.com/bastibe/lunatic-python/issues/29](https://github.com/bastibe/lunatic-python/issues/29).