### PR TITLE
improve intput_http

### DIFF
--- a/mjpg-streamer-experimental/plugins/input_http/misc.c
+++ b/mjpg-streamer-experimental/plugins/input_http/misc.c
@@ -21,7 +21,7 @@
 
 // dumb 4 byte storing to detect double CRLF
 int is_crlf(int bytes) {
-    int result = (((13 << 8) | (10)) & bytes) == ((13 << 8) | (10));
+    int result = ( 0xffff & bytes) == ((13 << 8) | (10));
     return result ;
 }
 

--- a/mjpg-streamer-experimental/plugins/input_http/mjpg-proxy.h
+++ b/mjpg-streamer-experimental/plugins/input_http/mjpg-proxy.h
@@ -37,6 +37,7 @@ struct extractor_state {
     
     char * port;
     char * hostname;
+    char * path;
 
     // this is current result
     char buffer [BUFFER_SIZE];
@@ -47,7 +48,8 @@ struct extractor_state {
     int sockfd;
     int part;
     int last_four_bytes;
-    struct search_pattern contentlength;
+    struct search_pattern contentlength_string;
+    struct search_pattern boundary_string;
     struct search_pattern boundary;
 
     int * should_stop;


### PR DESCRIPTION
Repairs a improvements of input_http to enable general usage, also for ipcams etc. 
There are still some unsolved TODOs from previous versions, but I still consider this to be quite satisfactory advance :-).