### PR TITLE
FindZeroMQ: fix header detection

### DIFF
--- a/mjpg-streamer-experimental/cmake/FindZeroMQ.cmake
+++ b/mjpg-streamer-experimental/cmake/FindZeroMQ.cmake
@@ -8,7 +8,7 @@ endif()
 
 ## use the hint from above to find where 'zmq.hpp' is located
 find_path(ZeroMQ_INCLUDE_DIR
-        NAMES zmq.hpp
+        NAMES zmq.h
         HINTS ${PC_ZeroMQ_INCLUDEDIR} ${PC_ZeroMQ_INCLUDE_DIRS}
         )
 


### PR DESCRIPTION
FindZeroMQ.cmake, added by

https://github.com/jacksonliam/mjpg-streamer/commit/8943c44e69d66650b9b1c5f873546579bfae7d2c#diff-1760adaac68b242c02c752a6efc72effR11

checks for zmq.hpp but the ZeroMQ output module includes zmq.h instead:

https://github.com/jacksonliam/mjpg-streamer/blob/master/mjpg-streamer-experimental/plugins/output_zmqserver/output_zmqserver.c#L40

so let's check for this file instead because the output module is not
written in C++. For reference see this Debian bug report about the split
of the zeromq and cppzmq packages:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=697743

This patch fixes a configure error on systems where cppzmq is not
present:
http://autobuild.buildroot.net/results/dad/dad054954de76cab56333747274520f269be2066/build-end.log