### PR TITLE
v4l2uvc: fix framesizeIn so that tmpbuffer isn't overrun

### DIFF
--- a/mjpg-streamer-experimental/plugins/input_uvc/v4l2uvc.c
+++ b/mjpg-streamer-experimental/plugins/input_uvc/v4l2uvc.c
@@ -229,7 +229,7 @@ error:
 
 static int init_framebuffer(struct vdIn *vd) {
     /* alloc a temp buffer to reconstruct the pict */
-    vd->framesizeIn = (vd->width * vd->height << 1);
+    vd->framesizeIn = (vd->width * vd->height << 1 * 2);
     switch (vd->formatIn) {
         case V4L2_PIX_FMT_JPEG:
             // Fall-through intentional


### PR DESCRIPTION
This seems to fix #193 for me.