### PR TITLE
Support for automatic systemd socket activation and timeout deactivation

### DIFF
--- a/mjpg-streamer-experimental/mjpg_streamer.c
+++ b/mjpg-streamer-experimental/mjpg_streamer.c
@@ -415,7 +415,10 @@ int main(int argc, char *argv[])
     }
 
     /* wait for signals */
-    pause();
+    while(!global.stop)
+        sleep(1);
+
+    raise(SIGINT);
 
     return 0;
 }

--- a/mjpg-streamer-experimental/mjpg_streamer@.service
+++ b/mjpg-streamer-experimental/mjpg_streamer@.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 User=mjpg_streamer
-ExecStart=/usr/bin/mjpg_streamer -i 'input_uvc.so -d /dev/%I' -o 'output_http.so -w /usr/share/mjpg_streamer/www'
+ExecStart=/usr/bin/mjpg_streamer -i 'input_uvc.so -d /dev/%I' -o 'output_http.so -w /usr/share/mjpg_streamer/www --timeout=10'
 
 [Install]
 WantedBy=multi-user.target

--- a/mjpg-streamer-experimental/mjpg_streamer@.socket
+++ b/mjpg-streamer-experimental/mjpg_streamer@.socket
@@ -1,0 +1,10 @@
+[Unit]
+Description=A socket for streaming Motion-JPEG from a video capture device
+PartOf=mjpg_streamer@.socket
+
+[Socket]
+ListenStream = 8080
+Accept = no
+
+[Install]
+WantedBy=sockets.target

--- a/mjpg-streamer-experimental/plugins/output_http/CMakeLists.txt
+++ b/mjpg-streamer-experimental/plugins/output_http/CMakeLists.txt
@@ -9,3 +9,4 @@ add_definitions(-D_GNU_SOURCE)
 
 MJPG_STREAMER_PLUGIN_OPTION(output_http "HTTP server output plugin")
 MJPG_STREAMER_PLUGIN_COMPILE(output_http httpd.c output_http.c)
+target_link_libraries(output_http systemd)

--- a/mjpg-streamer-experimental/plugins/output_http/httpd.h
+++ b/mjpg-streamer-experimental/plugins/output_http/httpd.h
@@ -124,6 +124,7 @@ typedef struct {
     char *credentials;
     char *www_folder;
     char nocommands;
+    int timeout;
 } config;
 
 /* context of each server thread */
@@ -133,6 +134,9 @@ typedef struct {
     int id;
     globals *pglobal;
     pthread_t threadID;
+
+    pthread_t *clients_list;
+    size_t clients_count;
 
     config conf;
 } context;

--- a/mjpg-streamer-experimental/plugins/output_http/output_http.c
+++ b/mjpg-streamer-experimental/plugins/output_http/output_http.c
@@ -83,6 +83,7 @@ int output_init(output_parameter *param, int id)
     int  port;
     char *credentials, *www_folder, *hostname = NULL;
     char nocommands;
+    int timeout;
 
     DBG("output #%02d\n", param->id);
 
@@ -90,6 +91,7 @@ int output_init(output_parameter *param, int id)
     credentials = NULL;
     www_folder = NULL;
     nocommands = 0;
+    timeout = -1;
 
     param->argv[0] = OUTPUT_PLUGIN_NAME;
 
@@ -115,6 +117,8 @@ int output_init(output_parameter *param, int id)
             {"www", required_argument, 0, 0},
             {"n", no_argument, 0, 0},
             {"nocommands", no_argument, 0, 0},
+            {"t", optional_argument, 0, 0},
+            {"timeout", optional_argument, 0, 0},
             {0, 0, 0, 0}
         };
 
@@ -175,6 +179,16 @@ int output_init(output_parameter *param, int id)
             DBG("case 10,11\n");
             nocommands = 1;
             break;
+
+            /* t, timeout */
+        case 12:
+        case 13:
+            DBG("case 12,13\n");
+            if (optarg) {
+                DBG(optarg);
+                timeout = atoi(optarg);
+            }
+            break;
         }
     }
 
@@ -185,12 +199,14 @@ int output_init(output_parameter *param, int id)
     servers[param->id].conf.credentials = credentials;
     servers[param->id].conf.www_folder = www_folder;
     servers[param->id].conf.nocommands = nocommands;
+    servers[param->id].conf.timeout = timeout;
 
     OPRINT("www-folder-path......: %s\n", (www_folder == NULL) ? "disabled" : www_folder);
     OPRINT("HTTP TCP port........: %d\n", ntohs(port));
     OPRINT("HTTP Listen Address..: %s\n", hostname);
     OPRINT("username:password....: %s\n", (credentials == NULL) ? "disabled" : credentials);
     OPRINT("commands.............: %s\n", (nocommands) ? "disabled" : "enabled");
+    OPRINT("timeout .............: %d\n", timeout);
 
     param->global->out[id].name = malloc((strlen(OUTPUT_PLUGIN_NAME) + 1) * sizeof(char));
     sprintf(param->global->out[id].name, OUTPUT_PLUGIN_NAME);


### PR DESCRIPTION
This PR contain two features:
1. for automatic service start, added support for systemd socket activation;
2. for automatic teardown, added timeout waiting for new connections.

Systemd socket activation uses systemd feature to start service when connection appears on socket and transfers open fd to application for further serving.

Timeout required to perform service deactivation. It sets time, when new connections will be established. Once connection is established and timeout reached, it will still serve existing connection and will teardown upon that connection close.