### PR TITLE
Remove bzero usage from the tree

### DIFF
--- a/mjpg-streamer-experimental/plugins/output_http/httpd.c
+++ b/mjpg-streamer-experimental/plugins/output_http/httpd.c
@@ -1453,7 +1453,7 @@ void *server_thread(void *arg)
     int on;
     pthread_t client;
     struct addrinfo *aip, *aip2;
-    struct addrinfo hints;
+    struct addrinfo hints = {};
     struct sockaddr_storage client_addr;
     socklen_t addr_len = sizeof(struct sockaddr_storage);
     fd_set selectfds;
@@ -1468,7 +1468,6 @@ void *server_thread(void *arg)
     /* set cleanup handler to cleanup resources */
     pthread_cleanup_push(server_cleanup, pcontext);
 
-    bzero(&hints, sizeof(hints));
     hints.ai_family = PF_UNSPEC;
     hints.ai_flags = AI_PASSIVE;
     hints.ai_socktype = SOCK_STREAM;

--- a/mjpg-streamer-experimental/plugins/output_rtsp/output_rtsp.c
+++ b/mjpg-streamer-experimental/plugins/output_rtsp/output_rtsp.c
@@ -132,13 +132,12 @@ void *worker_thread(void *arg)
         OPRINT("a valid UDP port must be provided\n");
         return NULL;
     }
-    struct sockaddr_in addr;
+    struct sockaddr_in addr = {};
     int sd;
     int bytes;
     unsigned int addr_len = sizeof(addr);
     char udpbuffer[1024] = {0};
     sd = socket(PF_INET, SOCK_DGRAM, 0);
-    bzero(&addr, sizeof(addr));
     addr.sin_family = AF_INET;
     addr.sin_addr.s_addr = INADDR_ANY;
     addr.sin_port = htons(port);

--- a/mjpg-streamer-experimental/plugins/output_udp/output_udp.c
+++ b/mjpg-streamer-experimental/plugins/output_udp/output_udp.c
@@ -128,13 +128,12 @@ void *worker_thread(void *arg)
         OPRINT("a valid UDP port must be provided\n");
         return NULL;
     }
-    struct sockaddr_in addr;
+    struct sockaddr_in addr = {};
     int sd;
     int bytes;
     unsigned int addr_len = sizeof(addr);
     char udpbuffer[1024] = {0};
     sd = socket(PF_INET, SOCK_DGRAM, 0);
-    bzero(&addr, sizeof(addr));
     addr.sin_family = AF_INET;
     addr.sin_addr.s_addr = INADDR_ANY;
     addr.sin_port = htons(port);


### PR DESCRIPTION
bzero has been deprecated by POSIX 2008 and optionally unavailable with
uClibc-ng.

{} also happens to generate more efficient code than bzero/memset.