### PR TITLE
Fix -vf false and -hf false option in input_uvc

### DIFF
--- a/mjpg-streamer-experimental/utils.h
+++ b/mjpg-streamer-experimental/utils.h
@@ -86,6 +86,7 @@ void daemon_mode(void);
         settings->v = 1; \
     } else if (strcasecmp("false", optarg) == 0) { \
         settings->v = 0; \
+    } else { \
         fprintf(stderr, "Invalid value '%s' for -" #v " (true/false accepted)\n", optarg); \
         exit(EXIT_FAILURE); \
     } \


### PR DESCRIPTION
fix input_uvc.so paramters.
-vf false and -hf false are not accepted.