### PR TITLE
Enable software framedropping also if higher FPS forced

### DIFF
--- a/mjpg-streamer-experimental/plugins/input_uvc/v4l2uvc.c
+++ b/mjpg-streamer-experimental/plugins/input_uvc/v4l2uvc.c
@@ -404,6 +404,12 @@ static int init_v4l2(struct vdIn *vd)
                 } else {
                     if (vd->fps != setfps->parm.capture.timeperframe.denominator) {
                         IPRINT("FPS coerced ......: from %d to %d\n", vd->fps, setfps->parm.capture.timeperframe.denominator);
+                        if(vd->fps < setfps->parm.capture.timeperframe.denominator){
+                            perror("Higher FPS coerced than specified, enabled software framedropping\n");
+                            vd->soft_framedrop = 1;
+                            vd->frame_period_time = 1000/vd->fps; // calcualate frame period time in ms
+                            IPRINT("Frame period time ......: %ld ms\n", vd->frame_period_time);
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
I found that, in some cases, actual FPS is higher than specified in option -f.

On current code, software framedropping is enabled only when command of setting FPS failed.
In case that the command returns success but the value is not accepted and higher fps is forced, it is not used.

After this update,
software framedropping is used also if command of setting FPS returns success but higher fps than specified is forced.

