### PR TITLE
Support for setting sensor mode

### DIFF
--- a/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.c
+++ b/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.c
@@ -598,6 +598,7 @@ void raspicamcontrol_dump_parameters(const RASPICAM_CAMERA_PARAMETERS *params)
    fprintf(stderr, "Metering Mode '%s', Colour Effect Enabled %s with U = %d, V = %d\n", metering_mode, params->colourEffects.enable ? "Yes":"No", params->colourEffects.u, params->colourEffects.v);
    fprintf(stderr, "Rotation %d, hflip %s, vflip %s\n", params->rotation, params->hflip ? "Yes":"No",params->vflip ? "Yes":"No");
    fprintf(stderr, "ROI x %lf, y %f, w %f h %f\n", params->roi.x, params->roi.y, params->roi.w, params->roi.h);
+   fprintf(stderr, "Sensor mode %d\n", params->sensor_mode);
 }
 
 /**
@@ -739,6 +740,7 @@ int raspicamcontrol_set_all_parameters(MMAL_COMPONENT_T *camera, const RASPICAM_
    result += raspicamcontrol_set_shutter_speed(camera, params->shutter_speed);
    result += raspicamcontrol_set_DRC(camera, params->drc_level);
    result += raspicamcontrol_set_stats_pass(camera, params->stats_pass);
+   result += raspicamcontrol_set_sensor_mode(camera, params->sensor_mode);
 
    return result;
 }
@@ -1173,6 +1175,20 @@ int raspicamcontrol_set_stereo_mode(MMAL_PORT_T *port, MMAL_PARAMETER_STEREOSCOP
       stereo.swap_eyes = stereo_mode->swap_eyes;
    }
    return mmal_status_to_int(mmal_port_parameter_set(port, &stereo.hdr));
+}
+
+/**
+ * Set sensor mode for the camera
+ * @param camera Pointer to camera component
+ * @param mode Value to set
+ * @return 0 if successful, non-zero if any parameters out of range
+ */
+int raspicamcontrol_set_sensor_mode(MMAL_COMPONENT_T *camera, int sensor_mode)
+{
+   if (!camera)
+      return 1;
+
+   return mmal_status_to_int(mmal_port_parameter_set_uint32(camera->control, MMAL_PARAMETER_CAMERA_CUSTOM_SENSOR_CONFIG, sensor_mode));
 }
 
 /**

--- a/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.h
+++ b/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.h
@@ -157,6 +157,7 @@ typedef struct
    int annotate_text_colour;  // Text colour for annotation
    int annotate_bg_colour;    // Background colour for annotation
    MMAL_PARAMETER_STEREOSCOPIC_MODE_T stereo_mode;
+   int sensor_mode;                  // Camera mode
 } RASPICAM_CAMERA_PARAMETERS;
 
 
@@ -197,6 +198,7 @@ int raspicamcontrol_set_stats_pass(MMAL_COMPONENT_T *camera, int stats_pass);
 int raspicamcontrol_set_annotate(MMAL_COMPONENT_T *camera, const int bitmask, const char *string,
                                  const int text_size, const int text_colour, const int bg_colour);
 int raspicamcontrol_set_stereo_mode(MMAL_PORT_T *port, MMAL_PARAMETER_STEREOSCOPIC_MODE_T *stereo_mode);
+int raspicamcontrol_set_sensor_mode(MMAL_COMPONENT_T *camera, int ISO);
 
 //Individual getting functions
 int raspicamcontrol_get_saturation(MMAL_COMPONENT_T *camera);
@@ -212,6 +214,6 @@ MMAL_PARAM_EXPOSUREMODE_T raspicamcontrol_get_exposure_mode(MMAL_COMPONENT_T *ca
 MMAL_PARAM_AWBMODE_T raspicamcontrol_get_awb_mode(MMAL_COMPONENT_T *camera);
 MMAL_PARAM_IMAGEFX_T raspicamcontrol_get_imageFX(MMAL_COMPONENT_T *camera);
 MMAL_PARAM_COLOURFX_T raspicamcontrol_get_colourFX(MMAL_COMPONENT_T *camera);
-
+int raspicamcontrol_get_mode(MMAL_COMPONENT_T *camera);
 
 #endif /* RASPICAMCONTROL_H_ */

--- a/mjpg-streamer-experimental/plugins/input_raspicam/input_raspicam.c
+++ b/mjpg-streamer-experimental/plugins/input_raspicam/input_raspicam.c
@@ -165,6 +165,7 @@ int input_init(input_parameter *param, int plugin_no)
       {"awbgainR", required_argument, 0, 0},          // 30
       {"awbgainB", required_argument, 0, 0},          // 31
       {"roi", required_argument, 0, 0},               // 32
+      {"mode", required_argument, 0, 0},              // 33
       {0, 0, 0, 0}
     };
 
@@ -307,6 +308,10 @@ int input_init(input_parameter *param, int plugin_no)
       case 32:
         // roi
         sscanf(optarg, "%lf,%lf,%lf,%lf", &c_params.roi.x, &c_params.roi.y, &c_params.roi.w, &c_params.roi.h);
+        break;
+      case 33:
+        // mode
+         sscanf(optarg, "%d", &c_params.sensor_mode);
         break;
       default:
         DBG("default case\n");
@@ -553,23 +558,24 @@ void help(void)
       " [-preview].............: Enable full screen preview\n"\
       " [-timestamp]...........: Get timestamp for each frame\n"
       " \n"\
-      " -sh  : Set image sharpness (-100 to 100)\n"\
-      " -co  : Set image contrast (-100 to 100)\n"\
-      " -br  : Set image brightness (0 to 100)\n"\
-      " -sa  : Set image saturation (-100 to 100)\n"\
-      " -ISO : Set capture ISO\n"\
-      " -vs  : Turn on video stablisation\n"\
-      " -ev  : Set EV compensation\n"\
-      " -ex  : Set exposure mode (see raspistill notes)\n"\
-      " -awb : Set AWB mode (see raspistill notes)\n"\
-      " -ifx : Set image effect (see raspistill notes)\n"\
-      " -cfx : Set colour effect (U:V)\n"\
-      " -mm  : Set metering mode (see raspistill notes)\n"\
-      " -rot : Set image rotation (0-359)\n"\
+      " -sh    : Set image sharpness (-100 to 100)\n"\
+      " -co    : Set image contrast (-100 to 100)\n"\
+      " -br    : Set image brightness (0 to 100)\n"\
+      " -sa    : Set image saturation (-100 to 100)\n"\
+      " -ISO   : Set capture ISO\n"\
+      " -vs    : Turn on video stablisation\n"\
+      " -ev    : Set EV compensation\n"\
+      " -ex    : Set exposure mode (see raspistill notes)\n"\
+      " -awb   : Set AWB mode (see raspistill notes)\n"\
+      " -ifx   : Set image effect (see raspistill notes)\n"\
+      " -cfx   : Set colour effect (U:V)\n"\
+      " -mm    : Set metering mode (see raspistill notes)\n"\
+      " -rot   : Set image rotation (0-359)\n"\
       " -stats : Compute image stats for each picture (reduces noise for -usestills)\n"\
-      " -drc : Dynamic range compensation level (see raspistill notes)\n"\
-      " -hf  : Set horizontal flip\n"\
-      " -vf  : Set vertical flip\n"\
+      " -drc   : Dynamic range compensation level (see raspistill notes)\n"\
+      " -hf    : Set horizontal flip\n"\
+      " -vf    : Set vertical flip\n"\
+      " -mode  : Set sensor mode (0 - auto)\n"\
       " ---------------------------------------------------------------\n");
 
 }


### PR DESCRIPTION
Add support for setting sensor mode for the camera. Without this setting I was unable to properly set output resolution - instead of showing full sensor output in chosen resolution, I had a crop of a chosen size from sensor's full res.