### PR TITLE
Patches

### DIFF
--- a/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.c
+++ b/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.c
@@ -910,7 +910,7 @@ int raspicamcontrol_set_exposure_compensation(MMAL_COMPONENT_T *camera, int exp_
    if (!camera)
       return 1;
 
-   return mmal_status_to_int(mmal_port_parameter_set_int32(camera->control, MMAL_PARAMETER_EXPOSURE_COMP , exp_comp));
+   return mmal_status_to_int(mmal_port_parameter_set_int32(camera->control, MMAL_PARAMETER_EXPOSURE_COMP, exp_comp));
 }
 
 
@@ -1069,7 +1069,7 @@ int raspicamcontrol_set_rotation(MMAL_COMPONENT_T *camera, int rotation)
    mmal_port_parameter_set_int32(camera->output[1], MMAL_PARAMETER_ROTATION, my_rotation);
    mmal_port_parameter_set_int32(camera->output[2], MMAL_PARAMETER_ROTATION, my_rotation);
 
-   return ret;
+   return mmal_status_to_int(ret);
 }
 
 /**
@@ -1095,7 +1095,7 @@ int raspicamcontrol_set_flips(MMAL_COMPONENT_T *camera, int hflip, int vflip)
 
    mmal_port_parameter_set(camera->output[0], &mirror.hdr);
    mmal_port_parameter_set(camera->output[1], &mirror.hdr);
-   return mmal_port_parameter_set(camera->output[2], &mirror.hdr);
+   return mmal_status_to_int(mmal_port_parameter_set(camera->output[2], &mirror.hdr));
 }
 
 /**
@@ -1114,7 +1114,7 @@ int raspicamcontrol_set_ROI(MMAL_COMPONENT_T *camera, PARAM_FLOAT_RECT_T rect)
    crop.rect.width = (65536 * rect.w);
    crop.rect.height = (65536 * rect.h);
 
-   return mmal_port_parameter_set(camera->control, &crop.hdr);
+   return mmal_status_to_int(mmal_port_parameter_set(camera->control, &crop.hdr));
 }
 
 /**

--- a/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.c
+++ b/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.c
@@ -148,32 +148,34 @@ static XREF_T stereo_mode_map[] =
 
 static const int stereo_mode_map_size = sizeof(stereo_mode_map)/sizeof(stereo_mode_map[0]);
 
-
-#define CommandSharpness   0
-#define CommandContrast    1
-#define CommandBrightness  2
-#define CommandSaturation  3
-#define CommandISO         4
-#define CommandVideoStab   5
-#define CommandEVComp      6
-#define CommandExposure    7
-#define CommandAWB         8
-#define CommandImageFX     9
-#define CommandColourFX    10
-#define CommandMeterMode   11
-#define CommandRotation    12
-#define CommandHFlip       13
-#define CommandVFlip       14
-#define CommandROI         15
-#define CommandShutterSpeed 16
-#define CommandAwbGains    17
-#define CommandDRCLevel    18
-#define CommandStatsPass   19
-#define CommandAnnotate    20
-#define CommandStereoMode  21
-#define CommandStereoDecimate 22
-#define CommandStereoSwap  23
-#define CommandAnnotateExtras 24
+enum
+{
+  CommandSharpness,
+  CommandContrast,
+  CommandBrightness,
+  CommandSaturation,
+  CommandISO,
+  CommandVideoStab,
+  CommandEVComp,
+  CommandExposure,
+  CommandAWB,
+  CommandImageFX,
+  CommandColourFX,
+  CommandMeterMode,
+  CommandRotation,
+  CommandHFlip,
+  CommandVFlip,
+  CommandROI,
+  CommandShutterSpeed,
+  CommandAwbGains,
+  CommandDRCLevel,
+  CommandStatsPass,
+  CommandAnnotate,
+  CommandStereoMode,
+  CommandStereoDecimate,
+  CommandStereoSwap,
+  CommandAnnotateExtras
+};
 
 static COMMAND_LIST  cmdline_commands[] =
 {

--- a/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.c
+++ b/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.c
@@ -34,8 +34,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "interface/vmcs_host/vc_vchi_gencmd.h"
 #include "mmal/mmal.h"
 //#include "mmal/mmal_logging.h"
-//#include "mmal/util/mmal_util.h"
-//#include "mmal/util/mmal_util_params.h"
+#include "mmal/util/mmal_util.h"
+#include "mmal/util/mmal_util_params.h"
 #include "mmal/util/mmal_default_components.h"
 #include "RaspiCamControl.h"
 

--- a/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.c
+++ b/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.c
@@ -1207,7 +1207,8 @@ static void raspicamcontrol_get_camera(int *supported, int *detected)
 }
 
 /**
- * Check to see if camera is supported, and we have allocated enough meooryAsk GPU about its camera abilities
+ * Check to see if camera is supported, and we have allocated enough memory
+ * Ask GPU about its camera abilities
  * @param supported None-zero if software supports the camera 
  * @param detected  None-zero if a camera has been detected
  */


### PR DESCRIPTION
On Raspbian OS, when you compile the raspbicam-module, you get a lot of compile warnings, complaining about undefined functions:
```
In file included from /home/pi/rippiedoos/mjpg-streamer/mjpg-streamer-experimental/plugins/input_raspicam/input_raspicam.c:51:
/home/pi/rippiedoos/mjpg-streamer/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.c: In function ‘raspicamcontrol_set_saturation’:
/home/pi/rippiedoos/mjpg-streamer/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.c:764:32: warning: implicit declaration of function ‘mmal_port_parameter_set_rational’; did you mean ‘mmal_port_parameter_set’? [-Wimplicit-function-declaration]
       ret = mmal_status_to_int(mmal_port_parameter_set_rational(camera->control, MMAL_PARAMETER_SATURATION, value));
                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                mmal_port_parameter_set
/home/pi/rippiedoos/mjpg-streamer/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.c: In function ‘raspicamcontrol_set_ISO’:
/home/pi/rippiedoos/mjpg-streamer/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.c:866:30: warning: implicit declaration of function ‘mmal_port_parameter_set_uint32’; did you mean ‘mmal_port_parameter_set’? [-Wimplicit-function-declaration]
    return mmal_status_to_int(mmal_port_parameter_set_uint32(camera->control, MMAL_PARAMETER_ISO, ISO));
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                              mmal_port_parameter_set
/home/pi/rippiedoos/mjpg-streamer/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.c: In function ‘raspicamcontrol_set_video_stabilisation’:
/home/pi/rippiedoos/mjpg-streamer/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.c:901:30: warning: implicit declaration of function ‘mmal_port_parameter_set_boolean’; did you mean ‘mmal_port_parameter_set’? [-Wimplicit-function-declaration]
    return mmal_status_to_int(mmal_port_parameter_set_boolean(camera->control, MMAL_PARAMETER_VIDEO_STABILISATION, vstabilisation));
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                              mmal_port_parameter_set
/home/pi/rippiedoos/mjpg-streamer/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.c: In function ‘raspicamcontrol_set_exposure_compensation’:
/home/pi/rippiedoos/mjpg-streamer/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.c:915:30: warning: implicit declaration of function ‘mmal_port_parameter_set_int32’; did you mean ‘mmal_port_parameter_set’? [-Wimplicit-function-declaration]
    return mmal_status_to_int(mmal_port_parameter_set_int32(camera->control, MMAL_PARAMETER_EXPOSURE_COMP, exp_comp));
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                              mmal_port_parameter_set
/home/pi/rippiedoos/mjpg-streamer/mjpg-streamer-experimental/plugins/input_raspicam/input_raspicam.c: In function ‘worker_thread’:
/home/pi/rippiedoos/mjpg-streamer/mjpg-streamer-experimental/plugins/input_raspicam/input_raspicam.c:885:10: warning: implicit declaration of function ‘mmal_port_pool_create’; did you mean ‘mmal_pool_create’? [-Wimplicit-function-declaration]
   pool = mmal_port_pool_create(encoder_output, encoder_output->buffer_num, encoder_output->buffer_size);
          ^~~~~~~~~~~~~~~~~~~~~
          mmal_pool_create
/home/pi/rippiedoos/mjpg-streamer/mjpg-streamer-experimental/plugins/input_raspicam/input_raspicam.c:885:8: warning: assignment to ‘MMAL_POOL_T *’ {aka ‘struct MMAL_POOL_T *’} from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
   pool = mmal_port_pool_create(encoder_output, encoder_output->buffer_num, encoder_output->buffer_size);
        ^
/home/pi/rippiedoos/mjpg-streamer/mjpg-streamer-experimental/plugins/input_raspicam/input_raspicam.c:1057:5: warning: implicit declaration of function ‘mmal_port_pool_destroy’; did you mean ‘mmal_pool_destroy’? [-Wimplicit-function-declaration]
     mmal_port_pool_destroy(encoder->output[0], pool);
     ^~~~~~~~~~~~~~~~~~~~~~
     mmal_pool_destroy
```

The fix for this was to include the header-files that where commented out so that functions are correctly declared.

There are also some returns that are correctly wrapped now, a typo fixed in a comment and converted all the command ID's to enums (https://github.com/raspberrypi/userland/pull/506).

These changes are all done compared to the upstream RaspiCamControl.c.

The module compiles now cleanly on my raspbian os (32 bit), up to date as of Oct 16th 2020.

```
pi@octopi:~ $ cat /etc/os-release 
PRETTY_NAME="Raspbian GNU/Linux 10 (buster)"
NAME="Raspbian GNU/Linux"
VERSION_ID="10"
VERSION="10 (buster)"
VERSION_CODENAME=buster
ID=raspbian
ID_LIKE=debian
HOME_URL="http://www.raspbian.org/"
SUPPORT_URL="http://www.raspbian.org/RaspbianForums"
BUG_REPORT_URL="http://www.raspbian.org/RaspbianBugs"
```
```
pi@octopi:~ $ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/arm-linux-gnueabihf/8/lto-wrapper
Target: arm-linux-gnueabihf
Configured with: ../src/configure -v --with-pkgversion='Raspbian 8.3.0-6+rpi1' --with-bugurl=file:///usr/share/doc/gcc-8/README.Bugs --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++ --prefix=/usr --with-gcc-major-version-only --program-suffix=-8 --program-prefix=arm-linux-gnueabihf- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --enable-bootstrap --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-libitm --disable-libquadmath --disable-libquadmath-support --enable-plugin --with-system-zlib --with-target-system-zlib --enable-objc-gc=auto --enable-multiarch --disable-sjlj-exceptions --with-arch=armv6 --with-fpu=vfp --with-float=hard --disable-werror --enable-checking=release --build=arm-linux-gnueabihf --host=arm-linux-gnueabihf --target=arm-linux-gnueabihf
Thread model: posix
gcc version 8.3.0 (Raspbian 8.3.0-6+rpi1) 
```
```
pi@octopi:~ $ uname -a
Linux octopi 5.4.72-v8+ #1356 SMP PREEMPT Thu Oct 22 13:58:52 BST 2020 aarch64 GNU/Linux
```