### PR TITLE
Add support for YU12

### DIFF
--- a/mjpg-streamer-experimental/plugins/input_uvc/input_uvc.c
+++ b/mjpg-streamer-experimental/plugins/input_uvc/input_uvc.c
@@ -215,6 +215,7 @@ int input_init(input_parameter *param, int id)
             {"softfps", required_argument, 0, 0},
             {"timeout", required_argument, 0, 0},
             {"dv_timings", no_argument, 0, 0},
+            {"yu12", no_argument, 0, 0},
             {0, 0, 0, 0}
         };
 
@@ -387,6 +388,12 @@ int input_init(input_parameter *param, int id)
             DBG("case 42\n");
             dv_timings = 1;
             break;
+        #ifndef NO_LIBJPEG
+        case 43:
+            DBG("case 43\n");
+            format = V4L2_PIX_FMT_YUV420;
+            break;
+        #endif
        default:
            DBG("default case\n");
            help();
@@ -422,9 +429,12 @@ int input_init(input_parameter *param, int id)
             case V4L2_PIX_FMT_UYVY:
                 fmtString = "UYVY";
                 break;
+            case V4L2_PIX_FMT_YUV420:
+                fmtString = "YU12";
+                break;
             case V4L2_PIX_FMT_RGB24:
                 fmtString = "RGB24";
-		break;
+		        break;
             case V4L2_PIX_FMT_RGB565:
                 fmtString = "RGB565";
                 break;
@@ -544,6 +554,7 @@ void help(void)
     " [-t | --tvnorm ] ......: set TV-Norm pal, ntsc or secam\n" \
     " [-u | --uyvy ] ........: Use UYVY format, default: MJPEG (uses more cpu power)\n" \
     " [-y | --yuv  ] ........: Use YUV format, default: MJPEG (uses more cpu power)\n" \
+    " [--yu12 ] .............: Use YU12 format, default: MJPEG (uses more cpu power)\n" \
     " [-fourcc ] ............: Use FOURCC codec 'argopt', \n" \
     "                          currently supported codecs are: RGB24, RGBP \n" \
     " [-timestamp ]..........: Populate frame timestamp with system time\n" \
@@ -781,6 +792,7 @@ void *cam_thread(void *arg)
             #ifndef NO_LIBJPEG
             if ((pcontext->videoIn->formatIn == V4L2_PIX_FMT_YUYV) ||
             (pcontext->videoIn->formatIn == V4L2_PIX_FMT_UYVY) ||
+            (pcontext->videoIn->formatIn == V4L2_PIX_FMT_YUV420) ||
             (pcontext->videoIn->formatIn == V4L2_PIX_FMT_RGB24) ||
             (pcontext->videoIn->formatIn == V4L2_PIX_FMT_RGB565) ) {
                 DBG("compressing frame from input: %d\n", (int)pcontext->id);

--- a/mjpg-streamer-experimental/plugins/input_uvc/input_uvc.c
+++ b/mjpg-streamer-experimental/plugins/input_uvc/input_uvc.c
@@ -434,7 +434,7 @@ int input_init(input_parameter *param, int id)
                 break;
             case V4L2_PIX_FMT_RGB24:
                 fmtString = "RGB24";
-		        break;
+		break;
             case V4L2_PIX_FMT_RGB565:
                 fmtString = "RGB565";
                 break;

--- a/mjpg-streamer-experimental/plugins/input_uvc/v4l2uvc.c
+++ b/mjpg-streamer-experimental/plugins/input_uvc/v4l2uvc.c
@@ -248,6 +248,7 @@ static int init_framebuffer(struct vdIn *vd) {
         case V4L2_PIX_FMT_RGB565: // buffer allocation for non varies on frame size formats
         case V4L2_PIX_FMT_YUYV:
         case V4L2_PIX_FMT_UYVY:
+        case V4L2_PIX_FMT_YUV420:
             vd->framebuffer =
                 (unsigned char *) calloc(1, (size_t) vd->framesizeIn);
             break;
@@ -370,6 +371,10 @@ static int init_v4l2(struct vdIn *vd)
         break;
       case V4L2_PIX_FMT_UYVY:
 	fprintf(stderr, "    ... Falling back to UYVY mode (consider using -uyvy option). Note that this requires much more CPU power\n");
+	vd->formatIn = vd->fmt.fmt.pix.pixelformat;
+        break;
+      case V4L2_PIX_FMT_YUV420:
+	fprintf(stderr, "    ... Falling back to YU12 mode (consider using -yu12 option). Note that this requires much more CPU power\n");
 	vd->formatIn = vd->fmt.fmt.pix.pixelformat;
         break;
       case V4L2_PIX_FMT_RGB24:
@@ -663,6 +668,7 @@ int uvcGrab(struct vdIn *vd)
     case V4L2_PIX_FMT_RGB565:
     case V4L2_PIX_FMT_YUYV:
     case V4L2_PIX_FMT_UYVY:
+    case V4L2_PIX_FMT_YUV420:
         if(vd->buf.bytesused > vd->framesizeIn) {
             memcpy(vd->framebuffer, vd->mem[vd->buf.index], (size_t) vd->framesizeIn);
         } else {


### PR DESCRIPTION
Inspired by https://github.com/pranjalv123/mjpg-streamer-yu12, I added YU12 (Planar YUV420) support.

More info about the YU12 format at https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/pixfmt-yuv420.html.

In summary, all Y's of the frame are located at the beginning of the buffer, followed by all U's, then all V's. Besides that special buffer format, the configuration (number and display location of Y, U and V components) is exactly the same as regular YUV.

Tested on latest official Octopi (https://github.com/guysoft/OctoPi)