### PR TITLE
Add info about the existing host/IP binding option

### DIFF
--- a/mjpg-streamer-experimental/plugins/output_http/README.md
+++ b/mjpg-streamer-experimental/plugins/output_http/README.md
@@ -15,6 +15,7 @@ The following parameters can be passed to this plugin:
 [-w | --www ]...........: folder that contains webpages in 
                           flat hierarchy (no subfolders)
 [-p | --port ]..........: TCP port for this HTTP server
+[-l ] --listen ]........: Listen on Hostname / IP
 [-c | --credentials ]...: ask for "username:password" on connect
 [-n | --nocommands ]....: disable execution of commands
 ---------------------------------------------------------------


### PR DESCRIPTION
It's an important feature, hence it should be mentioned in the readme:
```
./mjpg_streamer -o 'output_http.so --help'
MJPG Streamer Version.: 2.0
 ---------------------------------------------------------------
 Help for output plugin..: HTTP output plugin
 ---------------------------------------------------------------
 The following parameters can be passed to this plugin:

 [-w | --www ]...........: folder that contains webpages in
                           flat hierarchy (no subfolders)
 [-p | --port ]..........: TCP port for this HTTP server
 [-l ] --listen ]........: Listen on Hostname / IP
 [-c | --credentials ]...: ask for "username:password" on connect
 [-n | --nocommands ]....: disable execution of commands
 ---------------------------------------------------------------
```