### PR TITLE
fix input_opencv and cvfilter_py always has unmet dependencies

### DIFF
--- a/mjpg-streamer-experimental/plugins/input_opencv/CMakeLists.txt
+++ b/mjpg-streamer-experimental/plugins/input_opencv/CMakeLists.txt
@@ -4,7 +4,7 @@
 find_package(OpenCV COMPONENTS core imgproc highgui videoio)
 
 MJPG_STREAMER_PLUGIN_OPTION(input_opencv "OpenCV input plugin"
-                            ONLYIF OpenCV_FOUND ${OpenCV_VERSION_MAJOR} EQUAL 3)
+                            ONLYIF OpenCV_FOUND "${OpenCV_VERSION_MAJOR} EQUAL 3")
 
 if (PLUGIN_INPUT_OPENCV)
     enable_language(CXX)

--- a/mjpg-streamer-experimental/plugins/input_opencv/filters/cvfilter_py/CMakeLists.txt
+++ b/mjpg-streamer-experimental/plugins/input_opencv/filters/cvfilter_py/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(PythonLibs)
 find_package(Numpy)
 
 MJPG_STREAMER_PLUGIN_OPTION(cvfilter_py "OpenCV python filter"
-                            ONLYIF PYTHONLIBS_FOUND NUMPY_FOUND ${PYTHON_VERSION_MAJOR} EQUAL 3)
+                            ONLYIF PYTHONLIBS_FOUND NUMPY_FOUND "${PYTHON_VERSION_MAJOR} EQUAL 3")
                             
 if (PLUGIN_CVFILTER_PY)
     include_directories(${PYTHON_INCLUDE_DIRS})


### PR DESCRIPTION
input_opencv, cvfilter_py: always has unmet dependencies

fix cmake instructions sytax to pass conditions right.

Signed-off-by: Eugene Rush rush.zlo@gmail.com