### PR TITLE
Allow input_http to use any MJPEG source

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Plugins
 Input plugins:
 
 * input_file
-* input_http
+* input_http ([documentation](mjpg-streamer-experimental/plugins/input_http/README.md))
 * input_opencv ([documentation](mjpg-streamer-experimental/plugins/input_opencv/README.md))
 * input_ptp2
 * input_raspicam ([documentation](mjpg-streamer-experimental/plugins/input_raspicam/README.md))

--- a/mjpg-streamer-experimental/plugins/input_http/README.md
+++ b/mjpg-streamer-experimental/plugins/input_http/README.md
@@ -1,0 +1,41 @@
+mjpg-streamer input plugin: input_http
+======================================
+
+This plugin provides JPEG data from MJPEG compatible webcams.
+
+Usage
+=====
+
+    mjpg_streamer -i 'input_http.so [options]'
+    
+```
+ ---------------------------------------------------------------
+ Help for input plugin..: HTTP Input plugin
+ ---------------------------------------------------------------
+ The following parameters can be passed to this plugin:
+
+ [-v | --version ]........: current SVN Revision
+ [-h | --help]............: show this message
+ [-H | --host]............: host, defaults to localhost
+ [-p | --port]............: port, defaults to 8080
+ [-r | --request].........: request, defaults to /?action=stream
+ [-c | --credentials].....: credentials, defaults to NULL
+ [-b | --boundary]........: boundary, defaults to --boundarydonotcross
+ ---------------------------------------------------------------
+```
+
+Originally this plugin only supported other mjpg-streamer instances. It becomes inherently more useful if you can stream any
+MJPEG stream. In my case some Annke and Hikvision cameras only allow a single connection to the MJPEG substream. Default behavior remains the same if no parameters are passed.
+
+Basic Authentication is handled via credentials parameter as user:password. Please be aware of the security implications of passing credentials clear text (albeit Base64) over HTTP.
+
+To find boundary string use (modify URL to match your stream source):
+
+```
+curl "http://user:pass@192.168.1.69/ISAPI/Streaming/channels/102/httpPreview" -m 1 > out.mjpg
+grep -a "\-\-" out.mjpg
+
+--boundarySample
+--boundarySample
+--boundarySample
+```

--- a/mjpg-streamer-experimental/plugins/input_http/input_http.c
+++ b/mjpg-streamer-experimental/plugins/input_http/input_http.c
@@ -87,6 +87,10 @@ int input_init(input_parameter *param, int plugin_no)
 
     IPRINT("host.............: %s\n", proxy.hostname);
     IPRINT("port.............: %s\n", proxy.port);
+    IPRINT("request..........: %s\n", proxy.request);
+    // Probably should mask this instead of displaying clear text
+    IPRINT("credentials......: %s\n", proxy.credentials);
+    IPRINT("boundary.........: %s\n", proxy.boundary);
 
     return 0;
 }

--- a/mjpg-streamer-experimental/plugins/input_http/mjpg-proxy.h
+++ b/mjpg-streamer-experimental/plugins/input_http/mjpg-proxy.h
@@ -21,7 +21,7 @@
 #define MJPG_PROXY_H
 
 #include "misc.h"
-
+#include "sys/types.h"
 
 #ifndef DBG
 #ifdef DEBUG
@@ -37,6 +37,9 @@ struct extractor_state {
     
     char * port;
     char * hostname;
+    char * request;
+    char * credentials;
+    char * boundary;
 
     // this is current result
     char buffer [BUFFER_SIZE];
@@ -47,13 +50,15 @@ struct extractor_state {
     int sockfd;
     int part;
     int last_four_bytes;
-    struct search_pattern contentlength;
-    struct search_pattern boundary;
+    struct search_pattern contentlength_pattern;
+    struct search_pattern boundary_pattern;
 
     int * should_stop;
     void (*on_image_received)(char * data, int length);
         
 };
+
+unsigned char * base64_encode(const unsigned char *src, size_t len, size_t *out_len);
 
 void init_mjpg_proxy(struct extractor_state  * state);
 


### PR DESCRIPTION
Added ability to specify request URL, credentials and boundary. Default behavior remains the same.