### PR TITLE
Add new upstream settings for raspi cameras

### DIFF
--- a/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.c
+++ b/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.c
@@ -484,7 +484,26 @@ static int raspicli_map_xref(const char *str, const XREF_T *map, int num_refs)
    return -1;
 }
 
+/**
+ * Function to take a mmal enum (as int) and return the string equivalent
+ * @param en Incoming int to match
+ * @param map Mapping data
+ * @param num_refs The number of items in the mapping data
+ * @return const pointer to string, or NULL if no match
+ */
+static const char *raspicli_unmap_xref(const int en, XREF_T *map, int num_refs)
+{
+   int i;
 
+   for (i=0;i<num_refs;i++)
+   {
+      if (en == map[i].mmal_mode)
+      {
+         return map[i].mode;
+      }
+   }
+   return NULL;
+}
 /**
  * Convert string to the MMAL parameter for exposure mode
  * @param str Incoming string to match

--- a/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.c
+++ b/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.c
@@ -28,17 +28,23 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdio.h>
 #include <memory.h>
+#include <ctype.h>
 
 #include "interface/vcos/vcos.h"
 
 #include "interface/vmcs_host/vc_vchi_gencmd.h"
 #include "mmal/mmal.h"
-//#include "mmal/mmal_logging.h"
-//#include "mmal/util/mmal_util.h"
-//#include "mmal/util/mmal_util_params.h"
-#include "mmal/util/mmal_default_components.h"
-#include "RaspiCamControl.h"
+//#include "interface/mmal/mmal_logging.h"
+//#include "interface/mmal/util/mmal_util.h"
+//#include "interface/mmal/util/mmal_util_params.h"
+#include "interface/mmal/util/mmal_default_components.h"
+#include "interface/mmal/util/mmal_connection.h"
 
+#include "RaspiCamControl.h"
+//#include "RaspiCLI.h"
+//#include "RaspiHelpers.h"
+
+#define vcos_log_error printf
 /// Cross reference structure, mode string against mode id
 typedef struct xref_t
 {
@@ -75,6 +81,18 @@ static XREF_T  exposure_map[] =
 
 static const int exposure_map_size = sizeof(exposure_map) / sizeof(exposure_map[0]);
 
+/// Structure to cross reference flicker avoid strings against the MMAL parameter equivalent
+
+static XREF_T  flicker_avoid_map[] =
+{
+   {"off",           MMAL_PARAM_FLICKERAVOID_OFF},
+   {"auto",          MMAL_PARAM_FLICKERAVOID_AUTO},
+   {"50hz",          MMAL_PARAM_FLICKERAVOID_50HZ},
+   {"60hz",          MMAL_PARAM_FLICKERAVOID_60HZ}
+};
+
+static const int flicker_avoid_map_size = sizeof(flicker_avoid_map) / sizeof(flicker_avoid_map[0]);
+
 /// Structure to cross reference awb strings against the MMAL parameter equivalent
 static XREF_T awb_map[] =
 {
@@ -87,7 +105,8 @@ static XREF_T awb_map[] =
    {"fluorescent",   MMAL_PARAM_AWBMODE_FLUORESCENT},
    {"incandescent",  MMAL_PARAM_AWBMODE_INCANDESCENT},
    {"flash",         MMAL_PARAM_AWBMODE_FLASH},
-   {"horizon",       MMAL_PARAM_AWBMODE_HORIZON}
+   {"horizon",       MMAL_PARAM_AWBMODE_HORIZON},
+   {"greyworld",     MMAL_PARAM_AWBMODE_GREYWORLD}
 };
 
 static const int awb_map_size = sizeof(awb_map) / sizeof(awb_map[0]);
@@ -115,7 +134,7 @@ static XREF_T imagefx_map[] =
    {"colourpoint",   MMAL_PARAM_IMAGEFX_COLOURPOINT},
    {"colourbalance", MMAL_PARAM_IMAGEFX_COLOURBALANCE},
    {"cartoon",       MMAL_PARAM_IMAGEFX_CARTOON}
- };
+};
 
 static const int imagefx_map_size = sizeof(imagefx_map) / sizeof(imagefx_map[0]);
 
@@ -148,32 +167,39 @@ static XREF_T stereo_mode_map[] =
 
 static const int stereo_mode_map_size = sizeof(stereo_mode_map)/sizeof(stereo_mode_map[0]);
 
-
-#define CommandSharpness   0
-#define CommandContrast    1
-#define CommandBrightness  2
-#define CommandSaturation  3
-#define CommandISO         4
-#define CommandVideoStab   5
-#define CommandEVComp      6
-#define CommandExposure    7
-#define CommandAWB         8
-#define CommandImageFX     9
-#define CommandColourFX    10
-#define CommandMeterMode   11
-#define CommandRotation    12
-#define CommandHFlip       13
-#define CommandVFlip       14
-#define CommandROI         15
-#define CommandShutterSpeed 16
-#define CommandAwbGains    17
-#define CommandDRCLevel    18
-#define CommandStatsPass   19
-#define CommandAnnotate    20
-#define CommandStereoMode  21
-#define CommandStereoDecimate 22
-#define CommandStereoSwap  23
-#define CommandAnnotateExtras 24
+enum
+{
+   CommandSharpness,
+   CommandContrast,
+   CommandBrightness,
+   CommandSaturation,
+   CommandISO,
+   CommandVideoStab,
+   CommandEVComp,
+   CommandExposure,
+   CommandAWB,
+   CommandImageFX,
+   CommandColourFX,
+   CommandMeterMode,
+   CommandRotation,
+   CommandHFlip,
+   CommandVFlip,
+   CommandROI,
+   CommandShutterSpeed,
+   CommandAwbGains,
+   CommandDRCLevel,
+   CommandStatsPass,
+   CommandAnnotate,
+   CommandStereoMode,
+   CommandStereoDecimate,
+   CommandStereoSwap,
+   CommandAnnotateExtras,
+   CommandFlicker,
+   CommandAnalogGain,
+   CommandDigitalGain,
+   CommandSettings,
+   CommandFocusWindow
+};
 
 static COMMAND_LIST  cmdline_commands[] =
 {
@@ -185,29 +211,37 @@ static COMMAND_LIST  cmdline_commands[] =
    {CommandVideoStab,   "-vstab",     "vs", "Turn on video stabilisation", 0},
    {CommandEVComp,      "-ev",        "ev", "Set EV compensation - steps of 1/6 stop",  1},
    {CommandExposure,    "-exposure",  "ex", "Set exposure mode (see Notes)", 1},
+   {CommandFlicker,     "-flicker",   "fli","Set flicker avoid mode (see Notes)", 1},
    {CommandAWB,         "-awb",       "awb","Set AWB mode (see Notes)", 1},
    {CommandImageFX,     "-imxfx",     "ifx","Set image effect (see Notes)", 1},
    {CommandColourFX,    "-colfx",     "cfx","Set colour effect (U:V)",  1},
    {CommandMeterMode,   "-metering",  "mm", "Set metering mode (see Notes)", 1},
-   {CommandRotation,    "-rotation",  "rot","Set image rotation (0-359)", 1},
+   {CommandRotation,    "-rotation",  "rot","Set image rotation (0, 90, 180, or 270)", 1},
    {CommandHFlip,       "-hflip",     "hf", "Set horizontal flip", 0},
    {CommandVFlip,       "-vflip",     "vf", "Set vertical flip", 0},
    {CommandROI,         "-roi",       "roi","Set region of interest (x,y,w,d as normalised coordinates [0.0-1.0])", 1},
    {CommandShutterSpeed,"-shutter",   "ss", "Set shutter speed in microseconds", 1},
    {CommandAwbGains,    "-awbgains",  "awbg", "Set AWB gains - AWB mode must be off", 1},
-   {CommandDRCLevel,    "-drc",       "drc", "Set DRC Level", 1},
+   {CommandDRCLevel,    "-drc",       "drc", "Set DRC Level (see Notes)", 1},
    {CommandStatsPass,   "-stats",     "st", "Force recomputation of statistics on stills capture pass"},
    {CommandAnnotate,    "-annotate",  "a",  "Enable/Set annotate flags or text", 1},
    {CommandStereoMode,  "-stereo",    "3d", "Select stereoscopic mode", 1},
    {CommandStereoDecimate,"-decimate","dec", "Half width/height of stereo image"},
    {CommandStereoSwap,  "-3dswap",    "3dswap", "Swap camera order for stereoscopic"},
-   {CommandAnnotateExtras,"-annotateex","ae",  "Set extra annotation parameters (text size, text colour(hex YUV), bg colour(hex YUV))", 2},
+   {CommandAnnotateExtras,"-annotateex","ae",  "Set extra annotation parameters (text size, text colour(hex YUV), bg colour(hex YUV), justify, x, y)", 2},
+   {CommandAnalogGain,  "-analoggain", "ag", "Set the analog gain (floating point)", 1},
+   {CommandDigitalGain, "-digitalgain", "dg", "Set the digital gain (floating point)", 1},
+   {CommandSettings,    "-settings",   "set","Retrieve camera settings and write to stdout", 0},
+   {CommandFocusWindow, "-focus",      "fw","Draw a window with the focus FoM value on the image.", 0},
 };
 
 static int cmdline_commands_size = sizeof(cmdline_commands) / sizeof(cmdline_commands[0]);
 
 
 #define parameter_reset -99999
+
+#define zoom_full_16P16 ((unsigned int)(65536 * 0.15))
+#define zoom_increment_16P16 (65536UL / 10)
 
 /**
  * Update the passed in parameter according to the rest of the parameters
@@ -269,8 +303,7 @@ int raspicamcontrol_cycle_test(MMAL_COMPONENT_T *camera)
          parameter++;
       }
    }
-   else
-   if (parameter == 1)
+   else if (parameter == 1)
    {
       // contrast
       if (update_cycle_parameter(&parameter_option, -100, 100, 10))
@@ -281,8 +314,7 @@ int raspicamcontrol_cycle_test(MMAL_COMPONENT_T *camera)
          parameter++;
       }
    }
-   else
-   if (parameter == 2)
+   else if (parameter == 2)
    {
       // brightness
       if (update_cycle_parameter(&parameter_option, 0, 100, 10))
@@ -293,8 +325,7 @@ int raspicamcontrol_cycle_test(MMAL_COMPONENT_T *camera)
          parameter++;
       }
    }
-   else
-   if (parameter == 3)
+   else if (parameter == 3)
    {
       // contrast
       if (update_cycle_parameter(&parameter_option, -100, 100, 10))
@@ -305,8 +336,7 @@ int raspicamcontrol_cycle_test(MMAL_COMPONENT_T *camera)
          raspicamcontrol_set_saturation(camera, 0);
       }
    }
-   else
-   if (parameter == 4)
+   else if (parameter == 4)
    {
       // EV
       if (update_cycle_parameter(&parameter_option, -10, 10, 4))
@@ -317,8 +347,7 @@ int raspicamcontrol_cycle_test(MMAL_COMPONENT_T *camera)
          parameter++;
       }
    }
-   else
-   if (parameter == 5)
+   else if (parameter == 5)
    {
       // MMAL_PARAM_EXPOSUREMODE_T
       if (update_cycle_parameter(&parameter_option, 0, exposure_map_size, 1))
@@ -329,8 +358,7 @@ int raspicamcontrol_cycle_test(MMAL_COMPONENT_T *camera)
          parameter++;
       }
    }
-   else
-   if (parameter == 6)
+   else if (parameter == 6)
    {
       // MMAL_PARAM_AWB_T
       if (update_cycle_parameter(&parameter_option, 0, awb_map_size, 1))
@@ -357,21 +385,21 @@ int raspicamcontrol_cycle_test(MMAL_COMPONENT_T *camera)
       MMAL_PARAM_COLOURFX_T colfx = {0,0,0};
       switch (parameter_option)
       {
-         case parameter_reset :
-            parameter_option = 1;
-            colfx.u = 128;
-            colfx.v = 128;
-            break;
-         case 1 :
-            parameter_option = 2;
-            colfx.u = 100;
-            colfx.v = 200;
-            break;
-         case 2 :
-            parameter_option = parameter_reset;
-            colfx.enable = 0;
-            parameter++;
-            break;
+      case parameter_reset :
+         parameter_option = 1;
+         colfx.u = 128;
+         colfx.v = 128;
+         break;
+      case 1 :
+         parameter_option = 2;
+         colfx.u = 100;
+         colfx.v = 200;
+         break;
+      case 2 :
+         parameter_option = parameter_reset;
+         colfx.enable = 0;
+         parameter++;
+         break;
       }
       raspicamcontrol_set_colourFX(camera, &colfx);
    }
@@ -442,7 +470,7 @@ int raspicamcontrol_cycle_test(MMAL_COMPONENT_T *camera)
  * @param num_refs The number of items in the mapping data
  * @return The integer match for the string, or -1 if no match
  */
-static int map_xref(const char *str, const XREF_T *map, int num_refs)
+static int raspicli_map_xref(const char *str, const XREF_T *map, int num_refs)
 {
 	int i;
 
@@ -456,26 +484,6 @@ static int map_xref(const char *str, const XREF_T *map, int num_refs)
    return -1;
 }
 
-/**
- * Function to take a mmal enum (as int) and return the string equivalent
- * @param en Incoming int to match
- * @param map Mapping data
- * @param num_refs The number of items in the mapping data
- * @return const pointer to string, or NULL if no match
- */
-static const char *unmap_xref(const int en, XREF_T *map, int num_refs)
-{
-   int i;
-
-   for (i=0;i<num_refs;i++)
-   {
-      if (en == map[i].mmal_mode)
-      {
-         return map[i].mode;
-      }
-   }
-   return NULL;
-}
 
 /**
  * Convert string to the MMAL parameter for exposure mode
@@ -484,13 +492,29 @@ static const char *unmap_xref(const int en, XREF_T *map, int num_refs)
  */
 static MMAL_PARAM_EXPOSUREMODE_T exposure_mode_from_string(const char *str)
 {
-   int i = map_xref(str, exposure_map, exposure_map_size);
+   int i = raspicli_map_xref(str, exposure_map, exposure_map_size);
 
    if( i != -1)
       return (MMAL_PARAM_EXPOSUREMODE_T)i;
 
-   fprintf(stderr,"Unknown exposure mode: %s", str);
+   vcos_log_error("Unknown exposure mode: %s", str);
    return MMAL_PARAM_EXPOSUREMODE_AUTO;
+}
+
+/**
+ * Convert string to the MMAL parameter for flicker avoid mode
+ * @param str Incoming string to match
+ * @return MMAL parameter matching the string, or the AUTO option if no match found
+ */
+static MMAL_PARAM_FLICKERAVOID_T flicker_avoid_mode_from_string(const char *str)
+{
+   int i = raspicli_map_xref(str, flicker_avoid_map, flicker_avoid_map_size);
+
+   if( i != -1)
+      return (MMAL_PARAM_FLICKERAVOID_T)i;
+
+   vcos_log_error("Unknown flicker avoid mode: %s", str);
+   return MMAL_PARAM_FLICKERAVOID_OFF;
 }
 
 /**
@@ -500,12 +524,12 @@ static MMAL_PARAM_EXPOSUREMODE_T exposure_mode_from_string(const char *str)
  */
 static MMAL_PARAM_AWBMODE_T awb_mode_from_string(const char *str)
 {
-   int i = map_xref(str, awb_map, awb_map_size);
+   int i = raspicli_map_xref(str, awb_map, awb_map_size);
 
    if( i != -1)
       return (MMAL_PARAM_AWBMODE_T)i;
 
-   fprintf(stderr,"Unknown awb mode: %s", str);
+   vcos_log_error("Unknown awb mode: %s", str);
    return MMAL_PARAM_AWBMODE_AUTO;
 }
 
@@ -516,12 +540,12 @@ static MMAL_PARAM_AWBMODE_T awb_mode_from_string(const char *str)
  */
 MMAL_PARAM_IMAGEFX_T imagefx_mode_from_string(const char *str)
 {
-   int i = map_xref(str, imagefx_map, imagefx_map_size);
+   int i = raspicli_map_xref(str, imagefx_map, imagefx_map_size);
 
    if( i != -1)
-     return (MMAL_PARAM_IMAGEFX_T)i;
+      return (MMAL_PARAM_IMAGEFX_T)i;
 
-   fprintf(stderr,"Unknown image fx: %s", str);
+   vcos_log_error("Unknown image fx: %s", str);
    return MMAL_PARAM_IMAGEFX_NONE;
 }
 
@@ -532,28 +556,28 @@ MMAL_PARAM_IMAGEFX_T imagefx_mode_from_string(const char *str)
  */
 static MMAL_PARAM_EXPOSUREMETERINGMODE_T metering_mode_from_string(const char *str)
 {
-   int i = map_xref(str, metering_mode_map, metering_mode_map_size);
+   int i = raspicli_map_xref(str, metering_mode_map, metering_mode_map_size);
 
    if( i != -1)
       return (MMAL_PARAM_EXPOSUREMETERINGMODE_T)i;
 
-   fprintf(stderr,"Unknown metering mode: %s", str);
+   vcos_log_error("Unknown metering mode: %s", str);
    return MMAL_PARAM_EXPOSUREMETERINGMODE_AVERAGE;
 }
 
- /**
+/**
  * Convert string to the MMAL parameter for DRC level
  * @param str Incoming string to match
  * @return MMAL parameter matching the string, or the AUTO option if no match found
  */
 static MMAL_PARAMETER_DRC_STRENGTH_T drc_mode_from_string(const char *str)
 {
-   int i = map_xref(str, drc_mode_map, drc_mode_map_size);
+   int i = raspicli_map_xref(str, drc_mode_map, drc_mode_map_size);
 
    if( i != -1)
       return (MMAL_PARAMETER_DRC_STRENGTH_T)i;
 
-   fprintf(stderr,"Unknown DRC level: %s", str);
+   vcos_log_error("Unknown DRC level: %s", str);
    return MMAL_PARAMETER_DRC_STRENGTH_OFF;
 }
 
@@ -564,20 +588,373 @@ static MMAL_PARAMETER_DRC_STRENGTH_T drc_mode_from_string(const char *str)
  */
 static MMAL_STEREOSCOPIC_MODE_T stereo_mode_from_string(const char *str)
 {
-   int i = map_xref(str, stereo_mode_map, stereo_mode_map_size);
+   int i = raspicli_map_xref(str, stereo_mode_map, stereo_mode_map_size);
 
    if( i != -1)
       return (MMAL_STEREOSCOPIC_MODE_T)i;
 
-   fprintf(stderr,"Unknown metering mode: %s", str);
+   vcos_log_error("Unknown metering mode: %s", str);
    return MMAL_STEREOSCOPIC_MODE_NONE;
 }
 
+/**
+ * Parse a possible command pair - command and parameter
+ * @param arg1 Command
+ * @param arg2 Parameter (could be NULL)
+ * @return How many parameters were used, 0,1,2
+ */
+int raspicamcontrol_parse_cmdline(RASPICAM_CAMERA_PARAMETERS *params, const char *arg1, const char *arg2)
+{
+   int command_id, used = 0, num_parameters;
 
+   if (!arg1)
+      return 0;
 
+   command_id = raspicli_get_command_id(cmdline_commands, cmdline_commands_size, arg1, &num_parameters);
 
+   // If invalid command, or we are missing a parameter, drop out
+   if (command_id==-1 || (command_id != -1 && num_parameters > 0 && arg2 == NULL))
+      return 0;
 
+   switch (command_id)
+   {
+   case CommandSharpness : // sharpness - needs single number parameter
+      sscanf(arg2, "%d", &params->sharpness);
+      used = 2;
+      break;
 
+   case CommandContrast : // contrast - needs single number parameter
+      sscanf(arg2, "%d", &params->contrast);
+      used = 2;
+      break;
+
+   case CommandBrightness : // brightness - needs single number parameter
+      sscanf(arg2, "%d", &params->brightness);
+      used = 2;
+      break;
+
+   case CommandSaturation : // saturation - needs single number parameter
+      sscanf(arg2, "%d", &params->saturation);
+      used = 2;
+      break;
+
+   case CommandISO : // ISO - needs single number parameter
+      sscanf(arg2, "%d", &params->ISO);
+      used = 2;
+      break;
+
+   case CommandVideoStab : // video stabilisation - if here, its on
+      params->videoStabilisation = 1;
+      used = 1;
+      break;
+
+   case CommandEVComp : // EV - needs single number parameter
+      sscanf(arg2, "%d", &params->exposureCompensation);
+      used = 2;
+      break;
+
+   case CommandExposure : // exposure mode - needs string
+      params->exposureMode = exposure_mode_from_string(arg2);
+      used = 2;
+      break;
+
+   case CommandFlicker : // flicker avoid mode - needs string
+      params->flickerAvoidMode = flicker_avoid_mode_from_string(arg2);
+      used = 2;
+      break;
+
+   case CommandAWB : // AWB mode - needs single number parameter
+      params->awbMode = awb_mode_from_string(arg2);
+      used = 2;
+      break;
+
+   case CommandImageFX : // Image FX - needs string
+      params->imageEffect = imagefx_mode_from_string(arg2);
+      used = 2;
+      break;
+
+   case CommandColourFX : // Colour FX - needs string "u:v"
+      sscanf(arg2, "%d:%d", &params->colourEffects.u, &params->colourEffects.v);
+      params->colourEffects.enable = 1;
+      used = 2;
+      break;
+
+   case CommandMeterMode:
+      params->exposureMeterMode = metering_mode_from_string(arg2);
+      used = 2;
+      break;
+
+   case CommandRotation : // Rotation - degree
+      sscanf(arg2, "%d", &params->rotation);
+      used = 2;
+      break;
+
+   case CommandHFlip :
+      params->hflip  = 1;
+      used = 1;
+      break;
+
+   case CommandVFlip :
+      params->vflip = 1;
+      used = 1;
+      break;
+
+   case CommandROI :
+   {
+      double x,y,w,h;
+      int args;
+
+      args = sscanf(arg2, "%lf,%lf,%lf,%lf", &x,&y,&w,&h);
+
+      if (args != 4 || x > 1.0 || y > 1.0 || w > 1.0 || h > 1.0)
+      {
+         return 0;
+      }
+
+      // Make sure we stay within bounds
+      if (x + w > 1.0)
+         w = 1 - x;
+
+      if (y + h > 1.0)
+         h = 1 - y;
+
+      params->roi.x = x;
+      params->roi.y = y;
+      params->roi.w = w;
+      params->roi.h = h;
+
+      used = 2;
+      break;
+   }
+
+   case CommandShutterSpeed : // Shutter speed needs single number parameter
+   {
+      sscanf(arg2, "%d", &params->shutter_speed);
+      used = 2;
+      break;
+   }
+
+   case CommandAwbGains :
+   {
+      double r,b;
+      int args;
+
+      args = sscanf(arg2, "%lf,%lf", &r,&b);
+
+      if (args != 2 || r > 8.0 || b > 8.0)
+      {
+         return 0;
+      }
+
+      params->awb_gains_r = r;
+      params->awb_gains_b = b;
+
+      used = 2;
+      break;
+   }
+
+   case CommandDRCLevel:
+   {
+      params->drc_level = drc_mode_from_string(arg2);
+      used = 2;
+      break;
+   }
+
+   case CommandStatsPass:
+   {
+      params->stats_pass = MMAL_TRUE;
+      used = 1;
+      break;
+   }
+
+   case CommandAnnotate:
+   {
+      char dummy;
+      unsigned int bitmask;
+      // If parameter is a number, assume its a bitmask, otherwise a string
+      if (sscanf(arg2, "%u%c", &bitmask, &dummy) == 1)
+      {
+         params->enable_annotate |= bitmask;
+      }
+      else
+      {
+         params->enable_annotate |= ANNOTATE_USER_TEXT;
+         //copy string char by char and replace "\n" with newline character
+         unsigned char c;
+         char const *s = arg2;
+         char *t = &params->annotate_string[0];
+         int n=0;
+         while ((c = *s++) && n < MMAL_CAMERA_ANNOTATE_MAX_TEXT_LEN_V3-1)
+         {
+            if (c == '\\' && *s)
+            {
+               switch (c = *s++)
+               {
+               case 'n':
+                  c = '\n';
+                  break;
+
+               default:
+                  c = '\\';
+                  s--;
+                  break;
+               }
+            }
+            *(t++) = c;
+            n++;
+         }
+         *t='\0';
+
+         //params->annotate_string[MMAL_CAMERA_ANNOTATE_MAX_TEXT_LEN_V3-1] = '\0';
+      }
+      used=2;
+      break;
+   }
+
+   case CommandAnnotateExtras:
+   {
+      // 3 parameters - text size (6-80), text colour (Hex VVUUYY) and background colour (Hex VVUUYY)
+      sscanf(arg2, "%u,%X,%X,%u,%u,%u", &params->annotate_text_size,
+             &params->annotate_text_colour,
+             &params->annotate_bg_colour,
+             &params->annotate_justify,
+             &params->annotate_x,
+             &params->annotate_y
+            );
+      used=2;
+      break;
+   }
+
+   case CommandStereoMode:
+   {
+      params->stereo_mode.mode = stereo_mode_from_string(arg2);
+      used = 2;
+      break;
+   }
+
+   case CommandStereoDecimate:
+   {
+      params->stereo_mode.decimate = MMAL_TRUE;
+      used = 1;
+      break;
+   }
+
+   case CommandStereoSwap:
+   {
+      params->stereo_mode.swap_eyes = MMAL_TRUE;
+      used = 1;
+      break;
+   }
+
+   case CommandAnalogGain:
+   {
+      double gain;
+      int args;
+
+      args = sscanf(arg2, "%lf", &gain);
+
+      if (args != 1 || gain > 16.0)
+      {
+         return 0;
+      }
+
+      params->analog_gain = gain;
+
+      used = 2;
+      break;
+   }
+   case CommandDigitalGain:
+   {
+      double gain;
+      int args;
+
+      args = sscanf(arg2, "%lf", &gain);
+
+      if (args != 1 || gain > 64.0)
+      {
+         return 0;
+      }
+
+      params->digital_gain = gain;
+
+      used = 2;
+      break;
+   }
+
+   case CommandSettings:
+   {
+      params->settings = 1;
+      used = 1;
+      break;
+   }
+
+   case CommandFocusWindow:
+   {
+      params->focus_window = 1;
+      used = 1;
+      break;
+   }
+
+   }
+
+   return used;
+}
+
+/**
+ * Display help for command line options
+ */
+void raspicamcontrol_display_help()
+{
+   int i;
+
+   fprintf(stdout, "\nImage parameter commands\n\n");
+
+   raspicli_display_help(cmdline_commands, cmdline_commands_size);
+
+   fprintf(stdout, "\n\nNotes\n\nExposure mode options :\n%s", exposure_map[0].mode );
+
+   for (i=1; i<exposure_map_size; i++)
+   {
+      fprintf(stdout, ",%s", exposure_map[i].mode);
+   }
+
+   fprintf(stdout, "\n\nFlicker avoid mode options :\n%s", flicker_avoid_map[0].mode );
+
+   for (i=1; i<flicker_avoid_map_size; i++)
+   {
+      fprintf(stdout, ",%s", flicker_avoid_map[i].mode);
+   }
+
+   fprintf(stdout, "\n\nAWB mode options :\n%s", awb_map[0].mode );
+
+   for (i=1; i<awb_map_size; i++)
+   {
+      fprintf(stdout, ",%s", awb_map[i].mode);
+   }
+
+   fprintf(stdout, "\n\nImage Effect mode options :\n%s", imagefx_map[0].mode );
+
+   for (i=1; i<imagefx_map_size; i++)
+   {
+      fprintf(stdout, ",%s", imagefx_map[i].mode);
+   }
+
+   fprintf(stdout, "\n\nMetering Mode options :\n%s", metering_mode_map[0].mode );
+
+   for (i=1; i<metering_mode_map_size; i++)
+   {
+      fprintf(stdout, ",%s", metering_mode_map[i].mode);
+   }
+
+   fprintf(stdout, "\n\nDynamic Range Compression (DRC) options :\n%s", drc_mode_map[0].mode );
+
+   for (i=1; i<drc_mode_map_size; i++)
+   {
+      fprintf(stdout, ",%s", drc_mode_map[i].mode);
+   }
+
+   fprintf(stdout, "\n");
+}
 
 
 /**
@@ -587,19 +964,20 @@ static MMAL_STEREOSCOPIC_MODE_T stereo_mode_from_string(const char *str)
  */
 void raspicamcontrol_dump_parameters(const RASPICAM_CAMERA_PARAMETERS *params)
 {
-   const char *exp_mode = unmap_xref(params->exposureMode, exposure_map, exposure_map_size);
-   const char *awb_mode = unmap_xref(params->awbMode, awb_map, awb_map_size);
-   const char *image_effect = unmap_xref(params->imageEffect, imagefx_map, imagefx_map_size);
-   const char *metering_mode = unmap_xref(params->exposureMeterMode, metering_mode_map, metering_mode_map_size);
+   const char *exp_mode = raspicli_unmap_xref(params->exposureMode, exposure_map, exposure_map_size);
+   const char *fl_mode = raspicli_unmap_xref(params->flickerAvoidMode, flicker_avoid_map, flicker_avoid_map_size);
+   const char *awb_mode = raspicli_unmap_xref(params->awbMode, awb_map, awb_map_size);
+   const char *image_effect = raspicli_unmap_xref(params->imageEffect, imagefx_map, imagefx_map_size);
+   const char *metering_mode = raspicli_unmap_xref(params->exposureMeterMode, metering_mode_map, metering_mode_map_size);
 
    fprintf(stderr, "Sharpness %d, Contrast %d, Brightness %d\n", params->sharpness, params->contrast, params->brightness);
    fprintf(stderr, "Saturation %d, ISO %d, Video Stabilisation %s, Exposure compensation %d\n", params->saturation, params->ISO, params->videoStabilisation ? "Yes": "No", params->exposureCompensation);
    fprintf(stderr, "Exposure Mode '%s', AWB Mode '%s', Image Effect '%s'\n", exp_mode, awb_mode, image_effect);
+   fprintf(stderr, "Flicker Avoid Mode '%s'\n", fl_mode);
    fprintf(stderr, "Metering Mode '%s', Colour Effect Enabled %s with U = %d, V = %d\n", metering_mode, params->colourEffects.enable ? "Yes":"No", params->colourEffects.u, params->colourEffects.v);
    fprintf(stderr, "Rotation %d, hflip %s, vflip %s\n", params->rotation, params->hflip ? "Yes":"No",params->vflip ? "Yes":"No");
    fprintf(stderr, "ROI x %lf, y %f, w %f h %f\n", params->roi.x, params->roi.y, params->roi.w, params->roi.h);
 }
-
 /**
  * Convert a MMAL status return value to a simple boolean of success
  * ALso displays a fault if code is not success
@@ -637,6 +1015,7 @@ int mmal_status_to_int(MMAL_STATUS_T status)
    }
 }
 
+
 /**
  * Give the supplied parameter block a set of default values
  * @params Pointer to parameter block
@@ -653,6 +1032,7 @@ void raspicamcontrol_set_defaults(RASPICAM_CAMERA_PARAMETERS *params)
    params->videoStabilisation = 0;
    params->exposureCompensation = 0;
    params->exposureMode = MMAL_PARAM_EXPOSUREMODE_AUTO;
+   params->flickerAvoidMode = MMAL_PARAM_FLICKERAVOID_OFF;
    params->exposureMeterMode = MMAL_PARAM_EXPOSUREMETERINGMODE_AVERAGE;
    params->awbMode = MMAL_PARAM_AWBMODE_AUTO;
    params->imageEffect = MMAL_PARAM_IMAGEFX_NONE;
@@ -692,20 +1072,21 @@ int raspicamcontrol_get_all_parameters(MMAL_COMPONENT_T *camera, RASPICAM_CAMERA
    if (!camera || !params)
       return 1;
 
-/* TODO : Write these get functions
-   params->sharpness = raspicamcontrol_get_sharpness(camera);
-   params->contrast = raspicamcontrol_get_contrast(camera);
-   params->brightness = raspicamcontrol_get_brightness(camera);
-   params->saturation = raspicamcontrol_get_saturation(camera);
-   params->ISO = raspicamcontrol_get_ISO(camera);
-   params->videoStabilisation = raspicamcontrol_get_video_stabilisation(camera);
-   params->exposureCompensation = raspicamcontrol_get_exposure_compensation(camera);
-   params->exposureMode = raspicamcontrol_get_exposure_mode(camera);
-   params->awbMode = raspicamcontrol_get_awb_mode(camera);
-   params->imageEffect = raspicamcontrol_get_image_effect(camera);
-   params->colourEffects = raspicamcontrol_get_colour_effect(camera);
-   params->thumbnailConfig = raspicamcontrol_get_thumbnail_config(camera);
-*/
+   /* TODO : Write these get functions
+      params->sharpness = raspicamcontrol_get_sharpness(camera);
+      params->contrast = raspicamcontrol_get_contrast(camera);
+      params->brightness = raspicamcontrol_get_brightness(camera);
+      params->saturation = raspicamcontrol_get_saturation(camera);
+      params->ISO = raspicamcontrol_get_ISO(camera);
+      params->videoStabilisation = raspicamcontrol_get_video_stabilisation(camera);
+      params->exposureCompensation = raspicamcontrol_get_exposure_compensation(camera);
+      params->exposureMode = raspicamcontrol_get_exposure_mode(camera);
+      params->flickerAvoidMode = raspicamcontrol_get_flicker_avoid_mode(camera);
+      params->awbMode = raspicamcontrol_get_awb_mode(camera);
+      params->imageEffect = raspicamcontrol_get_image_effect(camera);
+      params->colourEffects = raspicamcontrol_get_colour_effect(camera);
+      params->thumbnailConfig = raspicamcontrol_get_thumbnail_config(camera);
+   */
    return 0;
 }
 
@@ -727,6 +1108,7 @@ int raspicamcontrol_set_all_parameters(MMAL_COMPONENT_T *camera, const RASPICAM_
    result += raspicamcontrol_set_video_stabilisation(camera, params->videoStabilisation);
    result += raspicamcontrol_set_exposure_compensation(camera, params->exposureCompensation);
    result += raspicamcontrol_set_exposure_mode(camera, params->exposureMode);
+   result += raspicamcontrol_set_flicker_avoid_mode(camera, params->flickerAvoidMode);
    result += raspicamcontrol_set_metering_mode(camera, params->exposureMeterMode);
    result += raspicamcontrol_set_awb_mode(camera, params->awbMode);
    result += raspicamcontrol_set_awb_gains(camera, params->awb_gains_r, params->awb_gains_b);
@@ -739,6 +1121,32 @@ int raspicamcontrol_set_all_parameters(MMAL_COMPONENT_T *camera, const RASPICAM_
    result += raspicamcontrol_set_shutter_speed(camera, params->shutter_speed);
    result += raspicamcontrol_set_DRC(camera, params->drc_level);
    result += raspicamcontrol_set_stats_pass(camera, params->stats_pass);
+   result += raspicamcontrol_set_annotate(camera, params->enable_annotate, params->annotate_string,
+                                          params->annotate_text_size,
+                                          params->annotate_text_colour,
+                                          params->annotate_bg_colour,
+                                          params->annotate_justify,
+                                          params->annotate_x,
+                                          params->annotate_y);
+   result += raspicamcontrol_set_gains(camera, params->analog_gain, params->digital_gain);
+   result += raspicamcontrol_set_focus_window(camera, params->focus_window);
+
+   if (params->settings)
+   {
+      MMAL_PARAMETER_CHANGE_EVENT_REQUEST_T change_event_request =
+      {
+         {MMAL_PARAMETER_CHANGE_EVENT_REQUEST, sizeof(MMAL_PARAMETER_CHANGE_EVENT_REQUEST_T)},
+         MMAL_PARAMETER_CAMERA_SETTINGS, 1
+      };
+
+      MMAL_STATUS_T status = mmal_port_parameter_set(camera->control, &change_event_request.hdr);
+      if ( status != MMAL_SUCCESS )
+      {
+         vcos_log_error("No camera settings events");
+      }
+
+      result += status;
+   }
 
    return result;
 }
@@ -763,7 +1171,7 @@ int raspicamcontrol_set_saturation(MMAL_COMPONENT_T *camera, int saturation)
    }
    else
    {
-      fprintf(stderr,"Invalid saturation value");
+      vcos_log_error("Invalid saturation value");
       ret = 1;
    }
 
@@ -789,7 +1197,7 @@ int raspicamcontrol_set_sharpness(MMAL_COMPONENT_T *camera, int sharpness)
    }
    else
    {
-      fprintf(stderr,"Invalid sharpness value");
+      vcos_log_error("Invalid sharpness value");
       ret = 1;
    }
 
@@ -816,7 +1224,7 @@ int raspicamcontrol_set_contrast(MMAL_COMPONENT_T *camera, int contrast)
    }
    else
    {
-      fprintf(stderr,"Invalid contrast value");
+      vcos_log_error("Invalid contrast value");
       ret = 1;
    }
 
@@ -843,7 +1251,7 @@ int raspicamcontrol_set_brightness(MMAL_COMPONENT_T *camera, int brightness)
    }
    else
    {
-      fprintf(stderr,"Invalid brightness value");
+      vcos_log_error("Invalid brightness value");
       ret = 1;
    }
 
@@ -877,7 +1285,8 @@ int raspicamcontrol_set_ISO(MMAL_COMPONENT_T *camera, int ISO)
 int raspicamcontrol_set_metering_mode(MMAL_COMPONENT_T *camera, MMAL_PARAM_EXPOSUREMETERINGMODE_T m_mode )
 {
    MMAL_PARAMETER_EXPOSUREMETERINGMODE_T meter_mode = {{MMAL_PARAMETER_EXP_METERING_MODE,sizeof(meter_mode)},
-                                                      m_mode};
+      m_mode
+   };
    if (!camera)
       return 1;
 
@@ -910,7 +1319,7 @@ int raspicamcontrol_set_exposure_compensation(MMAL_COMPONENT_T *camera, int exp_
    if (!camera)
       return 1;
 
-   return mmal_status_to_int(mmal_port_parameter_set_int32(camera->control, MMAL_PARAMETER_EXPOSURE_COMP , exp_comp));
+   return mmal_status_to_int(mmal_port_parameter_set_int32(camera->control, MMAL_PARAMETER_EXPOSURE_COMP, exp_comp));
 }
 
 
@@ -942,6 +1351,28 @@ int raspicamcontrol_set_exposure_mode(MMAL_COMPONENT_T *camera, MMAL_PARAM_EXPOS
       return 1;
 
    return mmal_status_to_int(mmal_port_parameter_set(camera->control, &exp_mode.hdr));
+}
+
+
+/**
+ * Set flicker avoid mode for images
+ * @param camera Pointer to camera component
+ * @param mode Exposure mode to set from
+ *   - MMAL_PARAM_FLICKERAVOID_OFF,
+ *   - MMAL_PARAM_FLICKERAVOID_AUTO,
+ *   - MMAL_PARAM_FLICKERAVOID_50HZ,
+ *   - MMAL_PARAM_FLICKERAVOID_60HZ,
+ *
+ * @return 0 if successful, non-zero if any parameters out of range
+ */
+int raspicamcontrol_set_flicker_avoid_mode(MMAL_COMPONENT_T *camera, MMAL_PARAM_FLICKERAVOID_T mode)
+{
+   MMAL_PARAMETER_FLICKERAVOID_T fl_mode = {{MMAL_PARAMETER_FLICKER_AVOID,sizeof(fl_mode)}, mode};
+
+   if (!camera)
+      return 1;
+
+   return mmal_status_to_int(mmal_port_parameter_set(camera->control, &fl_mode.hdr));
 }
 
 
@@ -1069,7 +1500,7 @@ int raspicamcontrol_set_rotation(MMAL_COMPONENT_T *camera, int rotation)
    mmal_port_parameter_set_int32(camera->output[1], MMAL_PARAMETER_ROTATION, my_rotation);
    mmal_port_parameter_set_int32(camera->output[2], MMAL_PARAMETER_ROTATION, my_rotation);
 
-   return ret;
+   return mmal_status_to_int(ret);
 }
 
 /**
@@ -1086,16 +1517,14 @@ int raspicamcontrol_set_flips(MMAL_COMPONENT_T *camera, int hflip, int vflip)
 
    if (hflip && vflip)
       mirror.value = MMAL_PARAM_MIRROR_BOTH;
-   else
-   if (hflip)
+   else if (hflip)
       mirror.value = MMAL_PARAM_MIRROR_HORIZONTAL;
-   else
-   if (vflip)
+   else if (vflip)
       mirror.value = MMAL_PARAM_MIRROR_VERTICAL;
 
    mmal_port_parameter_set(camera->output[0], &mirror.hdr);
    mmal_port_parameter_set(camera->output[1], &mirror.hdr);
-   return mmal_port_parameter_set(camera->output[2], &mirror.hdr);
+   return mmal_status_to_int(mmal_port_parameter_set(camera->output[2], &mirror.hdr));
 }
 
 /**
@@ -1114,7 +1543,83 @@ int raspicamcontrol_set_ROI(MMAL_COMPONENT_T *camera, PARAM_FLOAT_RECT_T rect)
    crop.rect.width = (65536 * rect.w);
    crop.rect.height = (65536 * rect.h);
 
-   return mmal_port_parameter_set(camera->control, &crop.hdr);
+   return mmal_status_to_int(mmal_port_parameter_set(camera->control, &crop.hdr));
+}
+
+/**
+ * Zoom in and Zoom out by changing ROI
+ * @param camera Pointer to camera component
+ * @param zoom_command zoom command enum
+ * @return 0 if successful, non-zero otherwise
+ */
+int raspicamcontrol_zoom_in_zoom_out(MMAL_COMPONENT_T *camera, ZOOM_COMMAND_T zoom_command, PARAM_FLOAT_RECT_T *roi)
+{
+   MMAL_PARAMETER_INPUT_CROP_T crop;
+   crop.hdr.id = MMAL_PARAMETER_INPUT_CROP;
+   crop.hdr.size = sizeof(crop);
+
+   if (mmal_port_parameter_get(camera->control, &crop.hdr) != MMAL_SUCCESS)
+   {
+      vcos_log_error("mmal_port_parameter_get(camera->control, &crop.hdr) failed, skip it");
+      return 0;
+   }
+
+   if (zoom_command == ZOOM_IN)
+   {
+      if (crop.rect.width <= (zoom_full_16P16 + zoom_increment_16P16))
+      {
+         crop.rect.width = zoom_full_16P16;
+         crop.rect.height = zoom_full_16P16;
+      }
+      else
+      {
+         crop.rect.width -= zoom_increment_16P16;
+         crop.rect.height -= zoom_increment_16P16;
+      }
+   }
+   else if (zoom_command == ZOOM_OUT)
+   {
+      unsigned int increased_size = crop.rect.width + zoom_increment_16P16;
+      if (increased_size < crop.rect.width) //overflow
+      {
+         crop.rect.width = 65536;
+         crop.rect.height = 65536;
+      }
+      else
+      {
+         crop.rect.width = increased_size;
+         crop.rect.height = increased_size;
+      }
+   }
+
+   if (zoom_command == ZOOM_RESET)
+   {
+      crop.rect.x = 0;
+      crop.rect.y = 0;
+      crop.rect.width = 65536;
+      crop.rect.height = 65536;
+   }
+   else
+   {
+      unsigned int centered_top_coordinate = (65536 - crop.rect.width) / 2;
+      crop.rect.x = centered_top_coordinate;
+      crop.rect.y = centered_top_coordinate;
+   }
+
+   int ret = mmal_status_to_int(mmal_port_parameter_set(camera->control, &crop.hdr));
+
+   if (ret == 0)
+   {
+      roi->x = roi->y = (double)crop.rect.x/65536;
+      roi->w = roi->h = (double)crop.rect.width/65536;
+   }
+   else
+   {
+      vcos_log_error("Failed to set crop values, x/y: %u, w/h: %u", crop.rect.x, crop.rect.width);
+      ret = 1;
+   }
+
+   return ret;
 }
 
 /**
@@ -1160,12 +1665,137 @@ int raspicamcontrol_set_stats_pass(MMAL_COMPONENT_T *camera, int stats_pass)
    return mmal_status_to_int(mmal_port_parameter_set_boolean(camera->control, MMAL_PARAMETER_CAPTURE_STATS_PASS, stats_pass));
 }
 
+int raspicamcontrol_set_focus_window(MMAL_COMPONENT_T *camera, int focus_window)
+{
+   if (!camera)
+      return 1;
 
+   return mmal_status_to_int(mmal_port_parameter_set_boolean(camera->control, MMAL_PARAMETER_DRAW_BOX_FACES_AND_FOCUS, focus_window));
+}
+
+/**
+ * Set the annotate data
+ * @param camera Pointer to camera component
+ * @param Bitmask of required annotation data. 0 for off.
+ * @param If set, a pointer to text string to use instead of bitmask, max length 32 characters
+ *
+ * @return 0 if successful, non-zero if any parameters out of range
+ */
+int raspicamcontrol_set_annotate(MMAL_COMPONENT_T *camera, const int settings, const char *string,
+                                 const int text_size, const int text_colour, const int bg_colour,
+                                 const unsigned int justify, const unsigned int x, const unsigned int y)
+{
+   MMAL_PARAMETER_CAMERA_ANNOTATE_V4_T annotate =
+   {{MMAL_PARAMETER_ANNOTATE, sizeof(MMAL_PARAMETER_CAMERA_ANNOTATE_V4_T)}};
+
+   if (settings)
+   {
+      time_t t = time(NULL);
+      struct tm tm = *localtime(&t);
+      char tmp[MMAL_CAMERA_ANNOTATE_MAX_TEXT_LEN_V4];
+      int process_datetime = 1;
+
+      annotate.enable = 1;
+
+      if (settings & (ANNOTATE_APP_TEXT | ANNOTATE_USER_TEXT))
+      {
+         if ((settings & (ANNOTATE_TIME_TEXT | ANNOTATE_DATE_TEXT)) && strchr(string,'%') != NULL)
+         {
+            //string contains strftime parameter?
+            strftime(annotate.text, MMAL_CAMERA_ANNOTATE_MAX_TEXT_LEN_V3, string, &tm );
+            process_datetime = 0;
+         }
+         else
+         {
+            strncpy(annotate.text, string, MMAL_CAMERA_ANNOTATE_MAX_TEXT_LEN_V3);
+         }
+         annotate.text[MMAL_CAMERA_ANNOTATE_MAX_TEXT_LEN_V3-1] = '\0';
+      }
+
+      if (process_datetime && (settings & ANNOTATE_TIME_TEXT))
+      {
+         if(strlen(annotate.text))
+         {
+            strftime(tmp, 32, " %X", &tm );
+         }
+         else
+         {
+            strftime(tmp, 32, "%X", &tm );
+         }
+         strncat(annotate.text, tmp, MMAL_CAMERA_ANNOTATE_MAX_TEXT_LEN_V3 - strlen(annotate.text) - 1);
+      }
+
+      if (process_datetime && (settings & ANNOTATE_DATE_TEXT))
+      {
+         if(strlen(annotate.text))
+         {
+            strftime(tmp, 32, " %x", &tm );
+         }
+         else
+         {
+            strftime(tmp, 32, "%x", &tm );
+         }
+         strncat(annotate.text, tmp, MMAL_CAMERA_ANNOTATE_MAX_TEXT_LEN_V3 - strlen(annotate.text) - 1);
+      }
+
+      if (settings & ANNOTATE_SHUTTER_SETTINGS)
+         annotate.show_shutter = MMAL_TRUE;
+
+      if (settings & ANNOTATE_GAIN_SETTINGS)
+         annotate.show_analog_gain = MMAL_TRUE;
+
+      if (settings & ANNOTATE_LENS_SETTINGS)
+         annotate.show_lens = MMAL_TRUE;
+
+      if (settings & ANNOTATE_CAF_SETTINGS)
+         annotate.show_caf = MMAL_TRUE;
+
+      if (settings & ANNOTATE_MOTION_SETTINGS)
+         annotate.show_motion = MMAL_TRUE;
+
+      if (settings & ANNOTATE_FRAME_NUMBER)
+         annotate.show_frame_num = MMAL_TRUE;
+
+      if (settings & ANNOTATE_BLACK_BACKGROUND)
+         annotate.enable_text_background = MMAL_TRUE;
+
+      annotate.text_size = text_size;
+
+      if (text_colour != -1)
+      {
+         annotate.custom_text_colour = MMAL_TRUE;
+         annotate.custom_text_Y = text_colour&0xff;
+         annotate.custom_text_U = (text_colour>>8)&0xff;
+         annotate.custom_text_V = (text_colour>>16)&0xff;
+      }
+      else
+         annotate.custom_text_colour = MMAL_FALSE;
+
+      if (bg_colour != -1)
+      {
+         annotate.custom_background_colour = MMAL_TRUE;
+         annotate.custom_background_Y = bg_colour&0xff;
+         annotate.custom_background_U = (bg_colour>>8)&0xff;
+         annotate.custom_background_V = (bg_colour>>16)&0xff;
+      }
+      else
+         annotate.custom_background_colour = MMAL_FALSE;
+
+      annotate.justify = justify;
+      annotate.x_offset = x;
+      annotate.y_offset = y;
+   }
+   else
+      annotate.enable = 0;
+
+   return mmal_status_to_int(mmal_port_parameter_set(camera->control, &annotate.hdr));
+}
 
 int raspicamcontrol_set_stereo_mode(MMAL_PORT_T *port, MMAL_PARAMETER_STEREOSCOPIC_MODE_T *stereo_mode)
 {
    MMAL_PARAMETER_STEREOSCOPIC_MODE_T stereo = { {MMAL_PARAMETER_STEREOSCOPIC_MODE, sizeof(stereo)},
-                               MMAL_STEREOSCOPIC_MODE_NONE, MMAL_FALSE, MMAL_FALSE };
+      MMAL_STEREOSCOPIC_MODE_NONE, MMAL_FALSE, MMAL_FALSE
+   };
    if (stereo_mode->mode != MMAL_STEREOSCOPIC_MODE_NONE)
    {
       stereo.mode = stereo_mode->mode;
@@ -1173,6 +1803,24 @@ int raspicamcontrol_set_stereo_mode(MMAL_PORT_T *port, MMAL_PARAMETER_STEREOSCOP
       stereo.swap_eyes = stereo_mode->swap_eyes;
    }
    return mmal_status_to_int(mmal_port_parameter_set(port, &stereo.hdr));
+}
+
+int raspicamcontrol_set_gains(MMAL_COMPONENT_T *camera, float analog, float digital)
+{
+   MMAL_RATIONAL_T rational = {0,65536};
+   MMAL_STATUS_T status;
+
+   if (!camera)
+      return 1;
+
+   rational.num = (unsigned int)(analog * 65536);
+   status = mmal_port_parameter_set_rational(camera->control, MMAL_PARAMETER_ANALOG_GAIN, rational);
+   if (status != MMAL_SUCCESS)
+      return mmal_status_to_int(status);
+
+   rational.num = (unsigned int)(digital * 65536);
+   status = mmal_port_parameter_set_rational(camera->control, MMAL_PARAMETER_DIGITAL_GAIN, rational);
+   return mmal_status_to_int(status);
 }
 
 /**
@@ -1191,7 +1839,7 @@ static int raspicamcontrol_get_mem_gpu(void)
 
 /**
  * Ask GPU about its camera abilities
- * @param supported None-zero if software supports the camera 
+ * @param supported None-zero if software supports the camera
  * @param detected  None-zero if a camera has been detected
  */
 static void raspicamcontrol_get_camera(int *supported, int *detected)
@@ -1207,8 +1855,9 @@ static void raspicamcontrol_get_camera(int *supported, int *detected)
 }
 
 /**
- * Check to see if camera is supported, and we have allocated enough meooryAsk GPU about its camera abilities
- * @param supported None-zero if software supports the camera 
+ * Check to see if camera is supported, and we have allocated enough memory
+ * Ask GPU about its camera abilities
+ * @param supported None-zero if software supports the camera
  * @param detected  None-zero if a camera has been detected
  */
 void raspicamcontrol_check_configuration(int min_gpu_mem)
@@ -1217,12 +1866,52 @@ void raspicamcontrol_check_configuration(int min_gpu_mem)
    int supported = 0, detected = 0;
    raspicamcontrol_get_camera(&supported, &detected);
    if (!supported)
-      fprintf(stderr,"Camera is not enabled in this build. Try running \"sudo raspi-config\" and ensure that \"camera\" has been enabled\n");
+      vcos_log_error("Camera is not enabled in this build. Try running \"sudo raspi-config\" and ensure that \"camera\" has been enabled\n");
    else if (gpu_mem < min_gpu_mem)
-      fprintf(stderr,"Only %dM of gpu_mem is configured. Try running \"sudo raspi-config\" and ensure that \"memory_split\" has a value of %d or greater\n", gpu_mem, min_gpu_mem);
+      vcos_log_error("Only %dM of gpu_mem is configured. Try running \"sudo raspi-config\" and ensure that \"memory_split\" has a value of %d or greater\n", gpu_mem, min_gpu_mem);
    else if (!detected)
-      fprintf(stderr,"Camera is not detected. Please check carefully the camera module is installed correctly\n");
+      vcos_log_error("Camera is not detected. Please check carefully the camera module is installed correctly\n");
    else
-      fprintf(stderr,"Failed to run camera app. Please check for firmware updates\n");
+      vcos_log_error("Failed to run camera app. Please check for firmware updates\n");
 }
 
+
+/** Default camera callback function
+ * Handles the --settings
+ * @param port
+ * @param Callback data
+ */
+void default_camera_control_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
+{
+   fprintf(stderr, "Camera control callback  cmd=0x%08x", buffer->cmd);
+
+   if (buffer->cmd == MMAL_EVENT_PARAMETER_CHANGED)
+   {
+      MMAL_EVENT_PARAMETER_CHANGED_T *param = (MMAL_EVENT_PARAMETER_CHANGED_T *)buffer->data;
+      switch (param->hdr.id)
+      {
+      case MMAL_PARAMETER_CAMERA_SETTINGS:
+      {
+         MMAL_PARAMETER_CAMERA_SETTINGS_T *settings = (MMAL_PARAMETER_CAMERA_SETTINGS_T*)param;
+         vcos_log_error("Exposure now %u, analog gain %u/%u, digital gain %u/%u",
+                        settings->exposure,
+                        settings->analog_gain.num, settings->analog_gain.den,
+                        settings->digital_gain.num, settings->digital_gain.den);
+         vcos_log_error("AWB R=%u/%u, B=%u/%u",
+                        settings->awb_red_gain.num, settings->awb_red_gain.den,
+                        settings->awb_blue_gain.num, settings->awb_blue_gain.den);
+      }
+      break;
+      }
+   }
+   else if (buffer->cmd == MMAL_EVENT_ERROR)
+   {
+      vcos_log_error("No data received from sensor. Check all connections, including the Sunny one on the camera board");
+   }
+   else
+   {
+      vcos_log_error("Received unexpected camera control callback event, 0x%08x", buffer->cmd);
+   }
+
+   mmal_buffer_header_release(buffer);
+}

--- a/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.h
+++ b/mjpg-streamer-experimental/plugins/input_raspicam/RaspiCamControl.h
@@ -46,6 +46,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             MMAL_PARAM_EXPOSUREMODE_ANTISHAKE,
             MMAL_PARAM_EXPOSUREMODE_FIREWORKS,
  *
+ * Flicker Avoid Mode
+ *          MMAL_PARAM_FLICKERAVOID_OFF,
+            MMAL_PARAM_FLICKERAVOID_AUTO,
+            MMAL_PARAM_FLICKERAVOID_50HZ,
+            MMAL_PARAM_FLICKERAVOID_60HZ,
+ *
  * AWB Mode
  *          MMAL_PARAM_AWBMODE_OFF,
             MMAL_PARAM_AWBMODE_AUTO,
@@ -57,6 +63,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             MMAL_PARAM_AWBMODE_INCANDESCENT,
             MMAL_PARAM_AWBMODE_FLASH,
             MMAL_PARAM_AWBMODE_HORIZON,
+            MMAL_PARAM_AWBMODE_GREYWORLD
  *
  * Image FX
             MMAL_PARAM_IMAGEFX_NONE,
@@ -105,20 +112,20 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 // There isn't actually a MMAL structure for the following, so make one
-typedef struct
+typedef struct mmal_param_colourfx_s
 {
    int enable;       /// Turn colourFX on or off
    int u,v;          /// U and V to use
 } MMAL_PARAM_COLOURFX_T;
 
-typedef struct
+typedef struct mmal_param_thumbnail_config_s
 {
    int enable;
    int width,height;
    int quality;
 } MMAL_PARAM_THUMBNAIL_CONFIG_T;
 
-typedef struct
+typedef struct param_float_rect_s
 {
    double x;
    double y;
@@ -127,7 +134,7 @@ typedef struct
 } PARAM_FLOAT_RECT_T;
 
 /// struct contain camera settings
-typedef struct
+typedef struct raspicam_camera_parameters_s
 {
    int sharpness;             /// -100 to 100
    int contrast;              /// -100 to 100
@@ -142,6 +149,7 @@ typedef struct
    MMAL_PARAM_IMAGEFX_T imageEffect;
    MMAL_PARAMETER_IMAGEFX_PARAMETERS_T imageEffectsParameters;
    MMAL_PARAM_COLOURFX_T colourEffects;
+   MMAL_PARAM_FLICKERAVOID_T flickerAvoidMode;
    int rotation;              /// 0-359
    int hflip;                 /// 0 or 1
    int vflip;                 /// 0 or 1
@@ -156,8 +164,22 @@ typedef struct
    int annotate_text_size;    // Text size for annotation
    int annotate_text_colour;  // Text colour for annotation
    int annotate_bg_colour;    // Background colour for annotation
+   unsigned int annotate_justify;
+   unsigned int annotate_x;
+   unsigned int annotate_y;
+   int focus_window;
+
    MMAL_PARAMETER_STEREOSCOPIC_MODE_T stereo_mode;
+   float analog_gain;         // Analog gain
+   float digital_gain;        // Digital gain
+
+   int settings;
 } RASPICAM_CAMERA_PARAMETERS;
+
+typedef enum
+{
+   ZOOM_IN, ZOOM_OUT, ZOOM_RESET
+} ZOOM_COMMAND_T;
 
 
 void raspicamcontrol_check_configuration(int min_gpu_mem);
@@ -184,6 +206,7 @@ int raspicamcontrol_set_metering_mode(MMAL_COMPONENT_T *camera, MMAL_PARAM_EXPOS
 int raspicamcontrol_set_video_stabilisation(MMAL_COMPONENT_T *camera, int vstabilisation);
 int raspicamcontrol_set_exposure_compensation(MMAL_COMPONENT_T *camera, int exp_comp);
 int raspicamcontrol_set_exposure_mode(MMAL_COMPONENT_T *camera, MMAL_PARAM_EXPOSUREMODE_T mode);
+int raspicamcontrol_set_flicker_avoid_mode(MMAL_COMPONENT_T *camera, MMAL_PARAM_FLICKERAVOID_T mode);
 int raspicamcontrol_set_awb_mode(MMAL_COMPONENT_T *camera, MMAL_PARAM_AWBMODE_T awb_mode);
 int raspicamcontrol_set_awb_gains(MMAL_COMPONENT_T *camera, float r_gain, float b_gain);
 int raspicamcontrol_set_imageFX(MMAL_COMPONENT_T *camera, MMAL_PARAM_IMAGEFX_T imageFX);
@@ -191,12 +214,16 @@ int raspicamcontrol_set_colourFX(MMAL_COMPONENT_T *camera, const MMAL_PARAM_COLO
 int raspicamcontrol_set_rotation(MMAL_COMPONENT_T *camera, int rotation);
 int raspicamcontrol_set_flips(MMAL_COMPONENT_T *camera, int hflip, int vflip);
 int raspicamcontrol_set_ROI(MMAL_COMPONENT_T *camera, PARAM_FLOAT_RECT_T rect);
+int raspicamcontrol_zoom_in_zoom_out(MMAL_COMPONENT_T *camera, ZOOM_COMMAND_T zoom_command, PARAM_FLOAT_RECT_T *roi);
 int raspicamcontrol_set_shutter_speed(MMAL_COMPONENT_T *camera, int speed_ms);
 int raspicamcontrol_set_DRC(MMAL_COMPONENT_T *camera, MMAL_PARAMETER_DRC_STRENGTH_T strength);
 int raspicamcontrol_set_stats_pass(MMAL_COMPONENT_T *camera, int stats_pass);
 int raspicamcontrol_set_annotate(MMAL_COMPONENT_T *camera, const int bitmask, const char *string,
-                                 const int text_size, const int text_colour, const int bg_colour);
+                                 const int text_size, const int text_colour, const int bg_colour,
+                                 const unsigned int justify, const unsigned int x, const unsigned int y);
 int raspicamcontrol_set_stereo_mode(MMAL_PORT_T *port, MMAL_PARAMETER_STEREOSCOPIC_MODE_T *stereo_mode);
+int raspicamcontrol_set_gains(MMAL_COMPONENT_T *camera, float analog, float digital);
+int raspicamcontrol_set_focus_window(MMAL_COMPONENT_T *camera, int focus_window);
 
 //Individual getting functions
 int raspicamcontrol_get_saturation(MMAL_COMPONENT_T *camera);
@@ -209,9 +236,15 @@ int raspicamcontrol_get_video_stabilisation(MMAL_COMPONENT_T *camera);
 int raspicamcontrol_get_exposure_compensation(MMAL_COMPONENT_T *camera);
 MMAL_PARAM_THUMBNAIL_CONFIG_T raspicamcontrol_get_thumbnail_parameters(MMAL_COMPONENT_T *camera);
 MMAL_PARAM_EXPOSUREMODE_T raspicamcontrol_get_exposure_mode(MMAL_COMPONENT_T *camera);
+MMAL_PARAM_FLICKERAVOID_T raspicamcontrol_get_flicker_avoid_mode(MMAL_COMPONENT_T *camera);
 MMAL_PARAM_AWBMODE_T raspicamcontrol_get_awb_mode(MMAL_COMPONENT_T *camera);
 MMAL_PARAM_IMAGEFX_T raspicamcontrol_get_imageFX(MMAL_COMPONENT_T *camera);
 MMAL_PARAM_COLOURFX_T raspicamcontrol_get_colourFX(MMAL_COMPONENT_T *camera);
+
+/** Default camera callback function
+  */
+void default_camera_control_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer);
+
 
 
 #endif /* RASPICAMCONTROL_H_ */

--- a/mjpg-streamer-experimental/plugins/input_raspicam/mmal/mmal_parameters_camera.h
+++ b/mjpg-streamer-experimental/plugins/input_raspicam/mmal/mmal_parameters_camera.h
@@ -136,6 +136,24 @@ enum {
    MMAL_PARAMETER_CAMERA_RX_CONFIG,          /**< Takes a @ref MMAL_PARAMETER_CAMERA_RX_CONFIG_T */
    MMAL_PARAMETER_CAMERA_RX_TIMING,          /**< Takes a @ref MMAL_PARAMETER_CAMERA_RX_TIMING_T */
    MMAL_PARAMETER_DPF_CONFIG,                /**< Takes a @ref MMAL_PARAMETER_UINT32_T */
+
+   /* 0x50 */
+   MMAL_PARAMETER_JPEG_RESTART_INTERVAL,     /**< Takes a @ref MMAL_PARAMETER_UINT32_T */
+   MMAL_PARAMETER_CAMERA_ISP_BLOCK_OVERRIDE, /**< Takes a @ref MMAL_PARAMETER_UINT32_T */
+   MMAL_PARAMETER_LENS_SHADING_OVERRIDE,     /**< Takes a @ref MMAL_PARAMETER_LENS_SHADING_T */
+   MMAL_PARAMETER_BLACK_LEVEL,               /**< Takes a @ref MMAL_PARAMETER_UINT32_T  or @ref MMAL_PARAMETER_BLACK_LEVEL_T */
+   MMAL_PARAMETER_RESIZE_PARAMS,             /**< Takes a @ref MMAL_PARAMETER_RESIZE_T */
+   MMAL_PARAMETER_CROP,                      /**< Takes a @ref MMAL_PARAMETER_CROP_T */
+   MMAL_PARAMETER_OUTPUT_SHIFT,              /**< Takes a @ref MMAL_PARAMETER_INT32_T */
+   MMAL_PARAMETER_CCM_SHIFT,                 /**< Takes a @ref MMAL_PARAMETER_INT32_T */
+   MMAL_PARAMETER_CUSTOM_CCM,                /**< Takes a @ref MMAL_PARAMETER_CUSTOM_CCM_T */
+   MMAL_PARAMETER_ANALOG_GAIN,               /**< Takes a @ref MMAL_PARAMETER_RATIONAL_T */
+   MMAL_PARAMETER_DIGITAL_GAIN,              /**< Takes a @ref MMAL_PARAMETER_RATIONAL_T */
+   MMAL_PARAMETER_DENOISE,                   /**< Takes a @ref MMAL_PARAMETER_DENOISE_T */
+   MMAL_PARAMETER_SHARPEN,                   /**< Takes a @ref MMAL_PARAMETER_SHARPEN_T */
+   MMAL_PARAMETER_GREEN_EQ,                  /**< Takes a @ref MMAL_PARAMETER_GREEN_EQ_T */
+   MMAL_PARAMETER_DPC,                       /**< Tales a @ref MMAP_PARAMETER_DPC_T */
+   MMAL_PARAMETER_GAMMA,                     /**< Tales a @ref MMAP_PARAMETER_GAMMA_T */
 };
 
 /** Thumbnail configuration parameter type */
@@ -215,6 +233,7 @@ typedef enum MMAL_PARAM_AWBMODE_T
    MMAL_PARAM_AWBMODE_INCANDESCENT,
    MMAL_PARAM_AWBMODE_FLASH,
    MMAL_PARAM_AWBMODE_HORIZON,
+   MMAL_PARAM_AWBMODE_GREYWORLD,
    MMAL_PARAM_AWBMODE_MAX = 0x7fffffff
 } MMAL_PARAM_AWBMODE_T;
 
@@ -769,6 +788,35 @@ typedef struct MMAL_PARAMETER_CAMERA_ANNOTATE_V3_T
    char text[MMAL_CAMERA_ANNOTATE_MAX_TEXT_LEN_V3];
 } MMAL_PARAMETER_CAMERA_ANNOTATE_V3_T;
 
+#define MMAL_CAMERA_ANNOTATE_MAX_TEXT_LEN_V4 256
+typedef struct MMAL_PARAMETER_CAMERA_ANNOTATE_V4_T
+{
+   MMAL_PARAMETER_HEADER_T hdr;
+
+   MMAL_BOOL_T enable;
+   MMAL_BOOL_T show_shutter;
+   MMAL_BOOL_T show_analog_gain;
+   MMAL_BOOL_T show_lens;
+   MMAL_BOOL_T show_caf;
+   MMAL_BOOL_T show_motion;
+   MMAL_BOOL_T show_frame_num;
+   MMAL_BOOL_T enable_text_background;
+   MMAL_BOOL_T custom_background_colour;
+   uint8_t     custom_background_Y;
+   uint8_t     custom_background_U;
+   uint8_t     custom_background_V;
+   uint8_t     dummy1;
+   MMAL_BOOL_T custom_text_colour;
+   uint8_t     custom_text_Y;
+   uint8_t     custom_text_U;
+   uint8_t     custom_text_V;
+   uint8_t     text_size;
+   char text[MMAL_CAMERA_ANNOTATE_MAX_TEXT_LEN_V3];
+   uint32_t    justify; //0=centre, 1=left, 2=right
+   uint32_t    x_offset; //Offset from the justification edge
+   uint32_t    y_offset;
+} MMAL_PARAMETER_CAMERA_ANNOTATE_V4_T;
+
 typedef enum MMAL_STEREOSCOPIC_MODE_T {
    MMAL_STEREOSCOPIC_MODE_NONE = 0,
    MMAL_STEREOSCOPIC_MODE_SIDE_BY_SIDE = 1,
@@ -888,5 +936,154 @@ typedef struct MMAL_PARAMETER_CAMERA_RX_TIMING_T
    uint32_t cpi_timing1;
    uint32_t cpi_timing2;
 } MMAL_PARAMETER_CAMERA_RX_TIMING_T;
+
+typedef struct MMAL_PARAMETER_LENS_SHADING_T
+{
+   MMAL_PARAMETER_HEADER_T hdr;
+
+   MMAL_BOOL_T enabled;
+   uint32_t grid_cell_size;
+   uint32_t grid_width;
+   uint32_t grid_stride;
+   uint32_t grid_height;
+   uint32_t mem_handle_table;
+   uint32_t ref_transform;
+} MMAL_PARAMETER_LENS_SHADING_T;
+
+typedef enum MMAL_PARAM_LS_GAIN_FORMAT_TYPE_T
+{
+   MMAL_PARAM_LS_GAIN_FORMAT_TYPE_U0P8_1 = 0,
+   MMAL_PARAM_LS_GAIN_FORMAT_TYPE_U1P7_0 = 1,
+   MMAL_PARAM_LS_GAIN_FORMAT_TYPE_U1P7_1 = 2,
+   MMAL_PARAM_LS_GAIN_FORMAT_TYPE_U2P6_0 = 3,
+   MMAL_PARAM_LS_GAIN_FORMAT_TYPE_U2P6_1 = 4,
+   MMAL_PARAM_LS_GAIN_FORMAT_TYPE_U3P5_0 = 5,
+   MMAL_PARAM_LS_GAIN_FORMAT_TYPE_U3P5_1 = 6,
+   MMAL_PARAM_LS_GAIN_FORMAT_TYPE_U4P10  = 7,
+   MMAL_PARAM_LS_GAIN_FORMAT_TYPE_DUMMY  = 0x7FFFFFFF
+} MMAL_PARAM_LS_GAIN_FORMAT_TYPE_T;
+
+typedef struct MMAL_PARAMETER_LENS_SHADING_V2_T
+{
+   MMAL_PARAMETER_HEADER_T hdr;
+
+   MMAL_BOOL_T enabled;
+   uint32_t grid_cell_size;
+   uint32_t grid_width;
+   uint32_t grid_stride;
+   uint32_t grid_height;
+   uint32_t mem_handle_table;
+   uint32_t ref_transform;
+   MMAL_BOOL_T corner_sampled;
+   MMAL_PARAM_LS_GAIN_FORMAT_TYPE_T gain_format;
+} MMAL_PARAMETER_LENS_SHADING_V2_T;
+
+/*
+The mode determines the kind of resize.
+MMAL_RESIZE_BOX allow the max_width and max_height to set a bounding box into
+which the output must fit.
+MMAL_RESIZE_BYTES allows max_bytes to set the maximum number of bytes into which the
+full output frame must fit.  Two flags aid the setting of the output
+size. preserve_aspect_ratio sets whether the resize should
+preserve the aspect ratio of the incoming
+image. allow_upscaling sets whether the resize is allowed to
+increase the size of the output image compared to the size of the
+input image.
+*/
+typedef enum MMAL_RESIZEMODE_T {
+   MMAL_RESIZE_NONE,
+   MMAL_RESIZE_CROP,
+   MMAL_RESIZE_BOX,
+   MMAL_RESIZE_BYTES,
+   MMAL_RESIZE_DUMMY = 0x7FFFFFFF
+} MMAL_RESIZEMODE_T;
+
+typedef struct MMAL_PARAMETER_RESIZE_T {
+   MMAL_PARAMETER_HEADER_T hdr;
+
+   MMAL_RESIZEMODE_T mode;
+   uint32_t max_width;
+   uint32_t max_height;
+   uint32_t max_bytes;
+   MMAL_BOOL_T preserve_aspect_ratio;
+   MMAL_BOOL_T allow_upscaling;
+} MMAL_PARAMETER_RESIZE_T;
+
+typedef struct MMAL_PARAMETER_CROP_T {
+   MMAL_PARAMETER_HEADER_T hdr;
+
+   MMAL_RECT_T rect;
+} MMAL_PARAMETER_CROP_T;
+
+typedef struct MMAL_PARAMETER_CCM_T {
+   MMAL_RATIONAL_T ccm[3][3];
+   int32_t offsets[3];
+} MMAL_PARAMETER_CCM_T;
+
+typedef struct MMAL_PARAMETER_CUSTOM_CCM_T {
+   MMAL_PARAMETER_HEADER_T hdr;
+
+   MMAL_BOOL_T enable;           /**< Enable the custom CCM. */
+   MMAL_PARAMETER_CCM_T ccm;     /**< CCM to be used. */
+} MMAL_PARAMETER_CUSTOM_CCM_T;
+
+typedef struct MMAL_PARAMETER_BLACK_LEVEL_T {
+   MMAL_PARAMETER_HEADER_T hdr;
+
+   MMAL_BOOL_T enable;                  /**< Enable denoise parameters. */
+   uint16_t black_level_r;              /**< Black level of red channel (out of 16 bits). */
+   uint16_t black_level_g;              /**< Black level of green channel (out of 16 bits). */
+   uint16_t black_level_b;              /**< Black level of blue channel (out of 16 bits). */
+} MMAL_PARAMETER_BLACK_LEVEL_T;
+
+typedef struct MMAL_PARAMETER_DENOISE_T {
+   MMAL_PARAMETER_HEADER_T hdr;
+
+   MMAL_BOOL_T enable;                  /**< Enable denoise parameters. */
+   uint32_t constant;                   /**< Constant offset of the noise profile. */
+   MMAL_RATIONAL_T slope;               /**< Slope of the noise profile. */
+   MMAL_RATIONAL_T strength;            /**< Denoise strength. */
+} MMAL_PARAMETER_DENOISE_T;
+
+typedef struct MMAL_PARAMETER_SHARPEN_T {
+   MMAL_PARAMETER_HEADER_T hdr;
+
+   MMAL_BOOL_T enable;                  /**< Enable sharpening parameters. */
+   MMAL_RATIONAL_T threshold;           /**< Threshold when sharpening starts. */
+   MMAL_RATIONAL_T strength;            /**< Rate at which sharpening ramps. */
+   MMAL_RATIONAL_T limit;               /**< Limit to total sharpening. */
+} MMAL_PARAMETER_SHARPEN_T;
+
+typedef struct MMAL_PARAMETER_GREEN_EQ_T {
+   MMAL_PARAMETER_HEADER_T hdr;
+
+   MMAL_BOOL_T enable;                  /**< Enable Green Equalisation parameters. */
+   uint32_t offset;                     /**< Offset of Green Equalisation threshold. */
+   MMAL_RATIONAL_T slope;               /**< Rate at which Green Equalisation threshold ramps. */
+} MMAL_PARAMETER_GREEN_EQ_T;
+
+typedef enum MMAL_DPC_MODE_T {
+   MMAL_DPC_MODE_OFF =    0,
+   MMAL_DPC_MODE_NORMAL = 1,
+   MMAL_DPC_MODE_STRONG = 2,
+   MMAL_DPC_MODE_MAX =    0x7FFFFFFF,
+} MMAL_DPC_MODE_T;
+
+typedef struct MMAL_PARAMETER_DPC_T {
+   MMAL_PARAMETER_HEADER_T hdr;
+
+   MMAL_BOOL_T enable;                  /**< Enable DPC parameters. */
+   MMAL_DPC_MODE_T strength;            /**< DPC strength. */
+} MMAL_PARAMETER_DPC_T;
+
+#define MMAL_NUM_GAMMA_PTS 33
+
+typedef struct MMAL_PARAMETER_GAMMA_T {
+   MMAL_PARAMETER_HEADER_T hdr;
+
+   MMAL_BOOL_T enable;                  /**< Enable gamma parameters. */
+   uint16_t X[MMAL_NUM_GAMMA_PTS];      /**< X values (16 bit range) */
+   uint16_t Y[MMAL_NUM_GAMMA_PTS];      /**< Y values (16 bit range) */
+} MMAL_PARAMETER_GAMMA_T;
 
 #endif  /* MMAL_PARAMETERS_CAMERA_H */


### PR DESCRIPTION
Merge in new upstream camera settings from https://github.com/raspberrypi/userland/
e.g.:

-roi
-flicker
-drc
-annotateex
-analoggain
-digitalgain
-settings
-focus