### PR TITLE
fix wrong include

### DIFF
--- a/mjpg-streamer-experimental/utils.c
+++ b/mjpg-streamer-experimental/utils.c
@@ -26,7 +26,7 @@
 #include <linux/types.h>
 #include <string.h>
 #include <fcntl.h>
-#include <wait.h>
+#include <sys/wait.h>
 #include <time.h>
 #include <limits.h>
 #include <linux/stat.h>


### PR DESCRIPTION
Fixes musl warning:

redirecting incorrect #include <wait.h> to <sys/wait.h>