### PR TITLE
Allow raspi camera plugin to build under Ubuntu

### DIFF
--- a/mjpg-streamer-experimental/plugins/input_raspicam/CMakeLists.txt
+++ b/mjpg-streamer-experimental/plugins/input_raspicam/CMakeLists.txt
@@ -1,5 +1,6 @@
-
-if (EXISTS /opt/vc/include)
+# Ubuntu libraspberrypi-dev places the raspberry header files under /usr/include so we
+# check for the vcos.h header
+if (EXISTS /opt/vc/include OR EXISTS /usr/include/interface/vcos/vcos.h)
     set(HAS_RASPI ON)
 else()
     set(HAS_RASPI OFF)


### PR DESCRIPTION
Ubuntu ships the libraspberrypi-dev packages that places the raspberry header files under /usr/include instead
under /opt. Extend the cmake logic to pick up also header files there.