### PR TITLE
Add support for v4l2loopback device

### DIFF
--- a/mjpg-streamer-experimental/plugins/input_uvc/v4l2uvc.h
+++ b/mjpg-streamer-experimental/plugins/input_uvc/v4l2uvc.h
@@ -41,7 +41,7 @@
 #include <linux/videodev2.h>
 
 #include "../../mjpg_streamer.h"
-#define NB_BUFFER 4
+#define NB_BUFFER 2
 
 
 #define IOCTL_RETRY 4


### PR DESCRIPTION
Hi, 

In continuation to the conversation at https://github.com/jacksonliam/mjpg-streamer/pull/280. 

This PR adds support for v4l2loopback devices simply by changing `NB_BUFFER` to 1. It seems like the reason `input_uvc` does not work is because it uses 4 buffers, while v4l2loopback devices only support 1.

This PR is definitely not a good solution, but a simple workaround. It's much better if we can add a parameter for the number of buffers. What do you think?

I agree with you that:

> It does seem strange to create a whole other plugin to get around some bug or missing implementation in v4l2loopback 


To reproduce, first, we create two virtual cameras (v4l2loopback devices) from one HD camera:

```
$ sudo modprobe v4l2loopback video_nr="40,41"
$ git clone https://github.com/wuhanstudio/v4l2loop_clone
$ cd v4l2loop_clone && make
$  ./v4l2loop_clone /dev/video0 /dev/video40 /dev/video41
```

Now, we can stream the video using mjpg-streamer:

```
$ git clone https://github.com/wuhanstudio/mjpg-streamer
$ cd mjpg-streamer/mjpg-streamer-experimental/ && make
$ ./mjpg_streamer -i "./input_uvc.so  -r 640x480 -d /dev/video40"  -o "./output_http.so -w ./www"
```
