### PR TITLE
Add suppprt for Raspberry Pi OS Bullseye (32bit)

### DIFF
--- a/mjpg-streamer-experimental/plugins/input_raspicam/CMakeLists.txt
+++ b/mjpg-streamer-experimental/plugins/input_raspicam/CMakeLists.txt
@@ -1,6 +1,8 @@
 
 if (EXISTS /opt/vc/include)
     set(HAS_RASPI ON)
+elseif (EXISTS /usr/include/interface/vcos AND CMAKE_SIZEOF_VOID_P EQUAL 4)
+    set(HAS_RASPI ON)
 else()
     set(HAS_RASPI OFF)
 endif()
@@ -15,6 +17,10 @@ if (PLUGIN_INPUT_RASPICAM)
     include_directories(/opt/vc/include/interface/vcos/pthreads)
     include_directories(/opt/vc/include/interface/vmcs_host)
     include_directories(/opt/vc/include/interface/vmcs_host/linux)
+    include_directories(/usr/include/interface/vcos)
+    include_directories(/usr/include/interface/vcos/pthreads)
+    include_directories(/usr/include/interface/vmcs_host)
+    include_directories(/usr/include/interface/vmcs_host/linux)
 
     link_directories(/opt/vc/lib)
 


### PR DESCRIPTION
On Raspberry Pi OS Bullseye, the plugin "input_raspicam.so" is not built because the directories inside "/opt/vc/include" is moved to "/usr/include". 

Therefore, I added new directories when users are using Bullseye (32-bit). The plugin "input_raspicam.so" works when Legacy Camera Mode is enabled. 

On the other hand, on the Bullseye (64-bit), the build of "input_raspicam.so" fails because there is no "libmmal_core.so" on Bullseye (64-bit). Therefore, I set HAS_RASPI OFF when users are using Bullseye (64-bit).

Of course, this patch also works when users are using older OSes.