### PR TITLE
Add NDI output support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,123 +1,44 @@
-mjpg-streamer
-=============
+mjpg-streamer with NDI output support
+=====================================
 
-This is a fork of http://sourceforge.net/projects/mjpg-streamer/ with added support for the Raspberry Pi camera via the input_raspicam plugin.
+Currently issues are known, but since this software is quite young and not used widely it may cause problems. You must really know what you are doing, if you use this software. If you want to use the software you are obliged to check if the sourcecode does what you expect it to do and take the risk yourself to use it.
 
-mjpg-streamer is a command line application that copies JPEG frames from one
-or more input plugins to multiple output plugins. It can be used to stream
-JPEG files over an IP-based network from a webcam to various types of viewers
-such as Chrome, Firefox, Cambozola, VLC, mplayer, and other software capable
-of receiving MJPG streams.
+The current implementation somehow messes up a bit of the streambuffer.
 
-It was originally written for embedded devices with very limited resources in
-terms of RAM and CPU. Its predecessor "uvc_streamer" was created because
-Linux-UVC compatible cameras directly produce JPEG-data, allowing fast and
-perfomant M-JPEG streams even from an embedded device running OpenWRT. The
-input module "input_uvc.so" captures such JPG frames from a connected webcam.
-mjpg-streamer now supports a variety of different input devices.
 
-Security warning
-----------------
+Usage
+=====
 
-**WARNING**: mjpg-streamer should not be used on untrusted networks!
-By default, anyone with access to the network that mjpg-streamer is running
-on will be able to access it.
+When launching mjpg-streamer, you specify one or more input plugins and an output plugin. For example, to stream a V4L compatible webcam via an HTTP server (the most common use case), you
+can do something like this:
 
-Plugins
--------
+	mjpg_streamer -i input_uvc.so -o output_ndi.so
+
+Each plugin supports various options, you can view the plugin's options via its `--help` option:
+
+	mjpg_streamer -i 'input_uvc.so --help'
+
+
+More examples can be found in the start.sh bash script.
+
+Plugin documentation
+====================
 
 Input plugins:
 
 * input_file
 * input_http
-* input_opencv ([documentation](mjpg-streamer-experimental/plugins/input_opencv/README.md))
+* input_opencv ([documentation](plugins/input_opencv/README.md))
 * input_ptp2
-* input_raspicam ([documentation](mjpg-streamer-experimental/plugins/input_raspicam/README.md))
-* input_uvc ([documentation](mjpg-streamer-experimental/plugins/input_uvc/README.md))
+* input_raspicam ([documentation](plugins/input_raspicam/README.md))
+* input_uvc ([documentation](plugins/input_uvc/README.md))
 
 Output plugins:
 
 * output_file
-* output_http ([documentation](mjpg-streamer-experimental/plugins/output_http/README.md))
+* output_http ([documentation](plugins/output_http/README.md))
 * ~output_rtsp~ (not functional)
 * ~output_udp~ (not functional)
-* output_viewer ([documentation](mjpg-streamer-experimental/plugins/output_viewer/README.md))
-* output_zmqserver ([documentation](mjpg-streamer-experimental/plugins/output_zmqserver/README.md))
+* output_ndi - NDI network stream output (can be used with OBS NDI etc.)
+* output_viewer ([documentation](plugins/output_viewer/README.md))
 
-Building & Installation
-=======================
-
-You must have cmake installed. You will also probably want to have a development
-version of libjpeg installed. I used libjpeg8-dev. e.g.
-
-    sudo apt-get install cmake libjpeg8-dev
-
-If you do not have gcc (and g++ for the opencv plugin) you may need to install those.
-
-    sudo apt-get install gcc g++
-
-Simple compilation
-------------------
-
-This will build and install all plugins that can be compiled.
-
-    cd mjpg-streamer-experimental
-    make
-    sudo make install
-    
-By default, everything will be compiled in "release" mode. If you wish to compile
-with debugging symbols enabled, you can do this:
-
-    cd mjpg-streamer-experimental
-    make distclean
-    make CMAKE_BUILD_TYPE=Debug
-    sudo make install
-    
-Advanced compilation (via CMake)
---------------------------------
-
-There are options available to enable/disable plugins, setup options, etc. This
-shows the basic steps to enable the experimental HTTP management feature:
-
-    cd mjpg-streamer-experimental
-    mkdir _build
-    cd _build
-    cmake -DENABLE_HTTP_MANAGEMENT=ON ..
-    make
-    sudo make install
-
-Usage
-=====
-From the mjpeg streamer experimental
-folder:
-```
-export LD_LIBRARY_PATH=.
-./mjpg_streamer -o "output_http.so -w ./www" -i "input_raspicam.so"
-```
-
-See [README.md](mjpg-streamer-experimental/README.md) or the individual plugin's documentation for more details.
-
-Discussion / Questions / Help
-=============================
-
-Probably best in this thread
-http://www.raspberrypi.org/phpBB3/viewtopic.php?f=43&t=45178
-
-Authors
-=======
-
-mjpg-streamer was originally created by Tom Stöveken, and has received
-improvements from many collaborators since then.
-
-
-License
-=======
-
-mjpg-streamer is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; version 2 of the License.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
-GNU General Public License for more details.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ The current implementation somehow messes up a bit of the streambuffer.
 Usage
 =====
 
-When launching mjpg-streamer, you specify one or more input plugins and an output plugin. For example, to stream a V4L compatible webcam via an HTTP server (the most common use case), you
-can do something like this:
+When launching mjpg-streamer, you specify one or more input plugins and an output plugin. For example, to stream a V4L compatible webcam via NDI, you can do something like this:
 
 	mjpg_streamer -i input_uvc.so -o output_ndi.so
 

--- a/mjpg-streamer-experimental/CMakeLists.txt
+++ b/mjpg-streamer-experimental/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
-project("mjpg-streamer" C)
+project("mjpg-streamer")
 
 # If the user doesn't manually specify a build type, use 'Release'
 message("CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
@@ -73,6 +73,7 @@ add_subdirectory(plugins/output_rtsp)
 add_subdirectory(plugins/output_udp)
 add_subdirectory(plugins/output_viewer)
 add_subdirectory(plugins/output_zmqserver)
+add_subdirectory(plugins/output_ndi)
 
 #
 # mjpg_streamer executable

--- a/mjpg-streamer-experimental/README.md
+++ b/mjpg-streamer-experimental/README.md
@@ -1,7 +1,9 @@
-mjpg-streamer
-=============
+mjpg-streamer with NDI output support
+=====================================
 
-Currently no issues are known, but since this software is quite young and not used widely it may cause problems. You must really know what you are doing, if you use this software. If you want to use the software you are obliged to check if the sourcecode does what you expect it to do and take the risk yourself to use it.
+Currently issues are known, but since this software is quite young and not used widely it may cause problems. You must really know what you are doing, if you use this software. If you want to use the software you are obliged to check if the sourcecode does what you expect it to do and take the risk yourself to use it.
+
+The current implementation somehow messes up a bit of the streambuffer.
 
 
 Usage
@@ -10,7 +12,7 @@ Usage
 When launching mjpg-streamer, you specify one or more input plugins and an output plugin. For example, to stream a V4L compatible webcam via an HTTP server (the most common use case), you
 can do something like this:
 
-	mjpg_streamer -i input_uvc.so -o output_http.so
+	mjpg_streamer -i input_uvc.so -o output_ndi.so
 
 Each plugin supports various options, you can view the plugin's options via its `--help` option:
 
@@ -37,5 +39,6 @@ Output plugins:
 * output_http ([documentation](plugins/output_http/README.md))
 * ~output_rtsp~ (not functional)
 * ~output_udp~ (not functional)
+* output_ndi - NDI network stream output (can be used with OBS NDI etc.)
 * output_viewer ([documentation](plugins/output_viewer/README.md))
 

--- a/mjpg-streamer-experimental/plugins/output_ndi/CMakeLists.txt
+++ b/mjpg-streamer-experimental/plugins/output_ndi/CMakeLists.txt
@@ -1,0 +1,5 @@
+
+MJPG_STREAMER_PLUGIN_OPTION(output_ndi "NDI output stream plugin" ONLYIF JPEG_LIB )
+MJPG_STREAMER_PLUGIN_COMPILE(output_ndi output_ndi.cpp)
+
+target_link_libraries(output_ndi ndi  ${JPEG_LIB})

--- a/mjpg-streamer-experimental/plugins/output_ndi/output_ndi.cpp
+++ b/mjpg-streamer-experimental/plugins/output_ndi/output_ndi.cpp
@@ -1,0 +1,519 @@
+/*******************************************************************************
+#                                                                              #
+#      MJPG-streamer allows to stream JPG frames from an input-plugin          #
+#      to several output plugins                                               #
+#                                                                              #
+#      Copyright (C) 2008 Tom Stöveken                                         #
+#                                                                              #
+# This program is free software; you can redistribute it and/or modify         #
+# it under the terms of the GNU General Public License as published by         #
+# the Free Software Foundation; version 2 of the License.                      #
+#                                                                              #
+# This program is distributed in the hope that it will be useful,              #
+# but WITHOUT ANY WARRANTY; without even the implied warranty of               #
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                #
+# GNU General Public License for more details.                                 #
+#                                                                              #
+# You should have received a copy of the GNU General Public License            #
+# along with this program; if not, write to the Free Software                  #
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA    #
+#                                                                              #
+*******************************************************************************/
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <getopt.h>
+#include <pthread.h>
+#include <syslog.h>
+
+#include <jpeglib.h>
+
+#include <map>
+
+#ifdef _WIN32
+#ifdef _WIN64
+#pragma comment(lib, "Processing.NDI.Lib.x64.lib")
+#else // _WIN64
+#pragma comment(lib, "Processing.NDI.Lib.x86.lib")
+#endif // _WIN64
+
+#include <windows.h>
+#endif
+
+#include "../../lib/NDI SDK for Linux/include/Processing.NDI.Lib.h"
+
+#include "../../utils.h"
+#include "../../mjpg_streamer.h"
+
+#define OUTPUT_PLUGIN_NAME "NDI output plugin"
+
+static pthread_t worker;
+static globals *pglobal;
+static unsigned char *frame = NULL;
+static int input_number = 0;
+
+std::map<int, void *> frame_buffers;
+std::map<int, NDIlib_video_frame_v2_t> frames;
+std::map<int, NDIlib_send_instance_t> senders;
+
+NDIlib_send_create_t NDI_send_create_desc;
+NDIlib_send_instance_t pNDI_send;
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /******************************************************************************
+    Description.: print a help message
+    Input Value.: -
+    Return Value: -
+    ******************************************************************************/
+    void help(void)
+    {
+        fprintf(stderr, " ---------------------------------------------------------------\n"
+                        " Help for output plugin..: " OUTPUT_PLUGIN_NAME "\n"
+                        " ---------------------------------------------------------------\n");
+    }
+
+    /******************************************************************************
+    Description.: clean up allocated resources
+    Input Value.: unused argument
+    Return Value: -
+    ******************************************************************************/
+    void worker_cleanup(void *arg)
+    {
+        static unsigned char first_run = 1;
+
+        if (!first_run)
+        {
+            DBG("already cleaned up resources\n");
+            return;
+        }
+
+        first_run = 0;
+        OPRINT("cleaning up resources allocated by worker thread\n");
+
+        free(frame);
+    }
+
+    typedef struct
+    {
+        struct jpeg_source_mgr pub;
+
+        uint8_t *jpegdata;
+        int jpegsize;
+    } my_source_mgr;
+
+    static void init_source(j_decompress_ptr cinfo)
+    {
+        return;
+    }
+
+    static int fill_input_buffer(j_decompress_ptr cinfo)
+    {
+        my_source_mgr *src = (my_source_mgr *)cinfo->src;
+
+        src->pub.next_input_byte = src->jpegdata;
+        src->pub.bytes_in_buffer = src->jpegsize;
+
+        return TRUE;
+    }
+
+    static void skip_input_data(j_decompress_ptr cinfo, long num_bytes)
+    {
+        my_source_mgr *src = (my_source_mgr *)cinfo->src;
+
+        if (num_bytes > 0)
+        {
+            src->pub.next_input_byte += (size_t)num_bytes;
+            src->pub.bytes_in_buffer -= (size_t)num_bytes;
+        }
+    }
+
+    static void term_source(j_decompress_ptr cinfo)
+    {
+        return;
+    }
+
+    static void jpeg_init_src(j_decompress_ptr cinfo, uint8_t *jpegdata, int jpegsize)
+    {
+        my_source_mgr *src;
+
+        if (cinfo->src == NULL)
+        { /* first time for this JPEG object? */
+            cinfo->src = (struct jpeg_source_mgr *)(*cinfo->mem->alloc_small)((j_common_ptr)cinfo, JPOOL_PERMANENT, sizeof(my_source_mgr));
+            src = (my_source_mgr *)cinfo->src;
+        }
+
+        src = (my_source_mgr *)cinfo->src;
+        src->pub.init_source = init_source;
+        src->pub.fill_input_buffer = fill_input_buffer;
+        src->pub.skip_input_data = skip_input_data;
+        src->pub.resync_to_restart = jpeg_resync_to_restart;
+        src->pub.term_source = term_source;
+        src->pub.bytes_in_buffer = 0;    /* forces fill_input_buffer on first read */
+        src->pub.next_input_byte = NULL; /* until buffer loaded */
+
+        src->jpegdata = jpegdata;
+        src->jpegsize = jpegsize;
+    }
+
+    static void my_error_exit(j_common_ptr cinfo)
+    {
+        DBG("JPEG data contains an error\n");
+    }
+
+    static void my_error_output_message(j_common_ptr cinfo)
+    {
+        DBG("JPEG data contains an error\n");
+    }
+
+    typedef struct
+    {
+        int height;
+        int width;
+        unsigned char *buffer;
+        int buffersize;
+    } decompressed_image;
+
+    int decompress_jpeg(unsigned char *jpeg, int jpegsize, decompressed_image *image)
+    {
+        struct jpeg_decompress_struct cinfo;
+        JSAMPROW rowptr[1];
+        struct jpeg_error_mgr jerr;
+
+        /* create an error handler that does not terminate MJPEG-streamer */
+        cinfo.err = jpeg_std_error(&jerr);
+        jerr.error_exit = my_error_exit;
+        jerr.output_message = my_error_output_message;
+
+        /* create the decompressor structures */
+        jpeg_create_decompress(&cinfo);
+
+        /* initalize the structures of decompressor */
+        jpeg_init_src(&cinfo, jpeg, jpegsize);
+
+        /* read the JPEG header data */
+        if (jpeg_read_header(&cinfo, TRUE) < 0)
+        {
+            jpeg_destroy_decompress(&cinfo);
+            DBG("could not read the header\n");
+            return 1;
+        }
+
+        /*
+         * I just expect RGB colored JPEGs, so the num_components must be three
+         */
+        if (cinfo.num_components != 3)
+        {
+            jpeg_destroy_decompress(&cinfo);
+            DBG("unsupported number of components (~colorspace)\n");
+            return 1;
+        }
+
+        /* just use RGB output and adjust decompression parameters */
+        cinfo.out_color_space = JCS_EXT_BGRX;
+        cinfo.quantize_colors = FALSE;
+        /* to scale the decompressed image, the fraction could be changed here */
+        cinfo.scale_num = 1;
+        cinfo.scale_denom = 1;
+        cinfo.dct_method = JDCT_FASTEST;
+        cinfo.do_fancy_upsampling = FALSE;
+
+        jpeg_calc_output_dimensions(&cinfo);
+
+        /* store the image information */
+        image->width = cinfo.output_width;
+        image->height = cinfo.output_height;
+
+        // printf("JPEG: %dx%d\n", image->width, image->height);
+
+        /*
+         * just allocate a new buffer if not already allocated
+         * pay a lot attention, that the calling function has to ensure, that the buffer
+         * must be large enough
+         */
+        if (image->buffer == NULL)
+        {
+            image->buffersize = image->width * image->height * cinfo.num_components;
+
+            /* the calling function has to ensure that this buffer will become freed after use! */
+            image->buffer = (unsigned char *)malloc(image->buffersize);
+            if (image->buffer == NULL)
+            {
+                jpeg_destroy_decompress(&cinfo);
+                DBG("allocating memory failed\n");
+                return 1;
+            }
+        }
+
+        /* start to decompress */
+        if (jpeg_start_decompress(&cinfo) < 0)
+        {
+            jpeg_destroy_decompress(&cinfo);
+            DBG("could not start decompression\n");
+            return 1;
+        }
+
+        while (cinfo.output_scanline < cinfo.output_height)
+        {
+            rowptr[0] = (JSAMPROW)(uint8_t *)image->buffer + cinfo.output_scanline * image->width * cinfo.num_components;
+
+            if (jpeg_read_scanlines(&cinfo, rowptr, (JDIMENSION)1) < 0)
+            {
+                jpeg_destroy_decompress(&cinfo);
+                DBG("could not decompress this line\n");
+                return 1;
+            }
+        }
+
+        if (jpeg_finish_decompress(&cinfo) < 0)
+        {
+            jpeg_destroy_decompress(&cinfo);
+            DBG("could not finish compression\n");
+            return 1;
+        }
+
+        /* all is done */
+        jpeg_destroy_decompress(&cinfo);
+
+        return 0;
+    }
+
+    /******************************************************************************
+    Description.: this is the main worker thread
+                  it loops forever, grabs a fresh frame, decompressed the JPEG
+                  and displays the decoded data using SDL
+    Input Value.:
+    Return Value:
+    ******************************************************************************/
+    void *worker_thread(void *arg)
+    {
+        int frame_size = 0, firstrun = 1;
+
+        static decompressed_image rgbimage;
+
+        /* initialze the buffer for the decompressed image */
+        rgbimage.buffersize = 0;
+        rgbimage.buffer = NULL;
+
+        /* just allocate a large buffer for the JPEGs */
+        if ((frame = (unsigned char *)malloc(8192 * 1024)) == NULL)
+        {
+            OPRINT("not enough memory for worker thread\n");
+            exit(EXIT_FAILURE);
+        }
+
+        /* set cleanup handler to cleanup allocated resources */
+        pthread_cleanup_push(worker_cleanup, NULL);
+
+        while (!pglobal->stop)
+        {
+            DBG("waiting for fresh frame\n");
+            pthread_mutex_lock(&pglobal->in[input_number].db);
+            pthread_cond_wait(&pglobal->in[input_number].db_update, &pglobal->in[input_number].db);
+
+            /* read buffer */
+            frame_size = pglobal->in[input_number].size;
+            memcpy(frame, pglobal->in[input_number].buf, frame_size);
+
+            pthread_mutex_unlock(&pglobal->in[input_number].db);
+
+
+            memset(rgbimage.buffer, 0xFF, rgbimage.width * rgbimage.height * 3);
+            /* decompress the JPEG and store results in memory */
+            if (decompress_jpeg(frame, frame_size, &rgbimage))
+            {
+                DBG("could not properly decompress JPEG data\n");
+                continue;
+            }
+
+            if (firstrun)
+            {
+                NDIlib_video_frame_v2_t NDI_video_frame;
+                NDI_video_frame.xres = rgbimage.width;
+                NDI_video_frame.yres = rgbimage.height;
+                NDI_video_frame.FourCC = NDIlib_FourCC_type_BGRA;
+                NDI_video_frame.line_stride_in_bytes = rgbimage.width * 3 ;
+                // NDI_video_frame.frame_rate_N = 60000;
+                // NDI_video_frame.frame_rate_D = 1200;
+                frame_buffers[0] = malloc(rgbimage.width * rgbimage.height * 3);
+                frames[0] = NDI_video_frame;
+                senders[0] = pNDI_send;
+
+                // clear the frame buffers
+                memset(frame_buffers[0], 0xFF, rgbimage.width * rgbimage.height * 3);
+
+                uint8_t c;
+
+                #ifdef TEST_PATTERN
+                for (int i = 0; i < rgbimage.height * rgbimage.width * 3; i += 4)
+                {
+                    memset(frame_buffers[0] + i, i % 255, 1);
+                    memset(frame_buffers[0] + i + 1, (i) % 255, 1);
+                    memset(frame_buffers[0] + i + 2, (i) % 255, 1);
+                    memset(frame_buffers[0] + i + 3, 255, 1);
+                    if (c < 255)
+                    {
+                        c++;
+                    }
+                    else
+                    {
+                        c = 0;
+                    }
+                }
+                #endif
+
+                frames[0].p_data = (uint8_t *)frame_buffers[0];
+                frames[0].xres = rgbimage.width;
+                frames[0].yres = rgbimage.height;
+
+                firstrun = 0;
+            }
+
+            /* copy the decoded data across */
+
+            memcpy(frame_buffers[0], rgbimage.buffer-200, rgbimage.width * rgbimage.height * 3);
+
+
+            //memcpy(buffer, rgbimage.buffer, rgbimage.width * rgbimage.height * 4);
+            //memcpy(frame_buffers[0], buffer, rgbimage.width * rgbimage.height * 4);
+
+            // if frame_buffers[0] is not empty, send it
+            if (frame_buffers[0] != nullptr)
+            {
+                NDIlib_send_send_video_v2(senders[0], &frames[0]);
+            }
+         
+
+            //NDIlib_send_send_video_v2(senders[0], &frames[0]);
+           // printf("Width %d Height %d Buffer Size: %d\n", rgbimage.width, rgbimage.height, rgbimage.buffersize);
+        }
+
+        pthread_cleanup_pop(1);
+
+        return NULL;
+    }
+
+    /*** plugin interface functions ***/
+    /******************************************************************************
+    Description.: this function is called first, in order to initialise
+                  this plugin and pass a parameter string
+    Input Value.: parameters
+    Return Value: 0 if everything is ok, non-zero otherwise
+    ******************************************************************************/
+
+    int output_init(output_parameter *param)
+    {
+
+        if (!NDIlib_initialize())
+        { // Cannot run NDI. Most likely because the CPU is not sufficient (see SDK documentation).
+            printf("Cannot run NDI.");
+            // return 0;
+        }
+
+        NDI_send_create_desc.p_ndi_name = "mjpeg-streamer";
+
+        pNDI_send = NDIlib_send_create(&NDI_send_create_desc);
+        if (!pNDI_send)
+        {
+            printf("NDP Send failed. is the NDI receiver running?\n");
+        }
+
+        int i;
+
+        param->argv[0] = OUTPUT_PLUGIN_NAME;
+
+        /* show all parameters for DBG purposes */
+        for (i = 0; i < param->argc; i++)
+        {
+            DBG("argv[%d]=%s\n", i, param->argv[i]);
+        }
+
+        reset_getopt();
+        while (1)
+        {
+            int option_index = 0, c = 0;
+            static struct option long_options[] = {
+                {"h", no_argument, 0, 0},
+                {"help", no_argument, 0, 0},
+                {"i", required_argument, 0, 0},
+                {"input", required_argument, 0, 0},
+                {0, 0, 0, 0}};
+
+            c = getopt_long_only(param->argc, param->argv, "", long_options, &option_index);
+
+            /* no more options to parse */
+            if (c == -1)
+                break;
+
+            /* unrecognized option */
+            if (c == '?')
+            {
+                help();
+                return 1;
+            }
+
+            switch (option_index)
+            {
+                /* h, help */
+            case 0:
+            case 1:
+                DBG("case 0,1\n");
+                help();
+                return 1;
+                break;
+                /* i, input */
+            case 2:
+            case 3:
+                DBG("case 2,3\n");
+                input_number = atoi(optarg);
+                break;
+            }
+        }
+
+        pglobal = param->global;
+        if (!(input_number < pglobal->incnt))
+        {
+            OPRINT("ERROR: the %d input_plugin number is too much only %d plugins loaded\n", input_number, pglobal->incnt);
+            return 1;
+        }
+        OPRINT("input plugin.....: %d: %s\n", input_number, pglobal->in[input_number].plugin);
+
+        return 0;
+    }
+
+    /******************************************************************************
+    Description.: calling this function stops the worker thread
+    Input Value.: -
+    Return Value: always 0
+    ******************************************************************************/
+    int output_stop(int id)
+    {
+        DBG("will cancel worker thread\n");
+        pthread_cancel(worker);
+        return 0;
+    }
+
+    /******************************************************************************
+    Description.: calling this function creates and starts the worker thread
+    Input Value.: -
+    Return Value: always 0
+    ******************************************************************************/
+    int output_run(int id)
+    {
+        DBG("launching worker thread\n");
+        pthread_create(&worker, 0, worker_thread, NULL);
+        pthread_detach(worker);
+        return 0;
+    }
+
+    int output_cmd()
+    {
+    }
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
"Network Device Interface (NDI) is a royalty-free software specification developed by [NewTek](https://en.wikipedia.org/wiki/NewTek) to enable video-compatible products to communicate, deliver, and receive [high-definition video](https://en.wikipedia.org/wiki/High-definition_video) over a [computer network](https://en.wikipedia.org/wiki/Computer_network) in a high-quality, low-latency manner that is [frame accurate](https://en.wikipedia.org/wiki/Frame_accurate) and suitable for switching in a live [production environment](https://en.wikipedia.org/wiki/Production_control_room)."

this adds NDI output support, but needs probably a fix, because at 3/4 of the image, 1st part of image is repeated.