### PR TITLE
Dockerfile update with compose file and README materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,58 @@ shows the basic steps to enable the experimental HTTP management feature:
 
 Usage
 =====
-From the mjpeg streamer experimental
-folder:
+
+Shell
+-----
+
+From the mjpg-streamer-experimental folder:
 ```
 export LD_LIBRARY_PATH=.
 ./mjpg_streamer -o "output_http.so -w ./www" -i "input_raspicam.so"
 ```
 
 See [README.md](mjpg-streamer-experimental/README.md) or the individual plugin's documentation for more details.
+
+Docker
+------
+
+**Build the mjpg-streamer image** 
+
+From the mjpg-streamer-experimental folder:
+
+***Note***: the example creates a docker image named `mjpg-streamer` that is used in the following steps; if a different name is used, update the steps below to match
+
+```
+docker build -t mjpg-streamer .
+```
+
+**Create a Docker Container** 
+
+After building the docker image, launch a container using either docker run or docker compose
+
+**Launch a container using `docker run`**:
+
+***Note***: ensure each argument string below is present and enclosed with quotes. Additionally, don't change the command input order from output, input
+
+```
+docker run \
+    -it \
+    --device /dev/video0:/dev/video0 \
+    -p 8080:8080 \
+    mjpg-streamer \
+    "output_http.so -w ./www" \
+    "input_uvc.so"
+```
+
+**Launch a container using `docker compose`**:
+
+***Note***: the docker compose example uses v2 of `docker/compose`; users still on v1 should update `docker compose` -> `docker-compose`
+
+From the mjpg-streamer-experimental folder:
+
+```
+docker compose -f docker-compose.yml up
+```
 
 Discussion / Questions / Help
 =============================

--- a/mjpg-streamer-experimental/Dockerfile
+++ b/mjpg-streamer-experimental/Dockerfile
@@ -15,6 +15,9 @@ RUN make \
 
 EXPOSE 8080/TCP
 
-ENTRYPOINT ["/mjpg-streamer/mjpg-streamer-experimental/docker-start.sh", "output_http.so -w ./www"]
+ENTRYPOINT ["/mjpg-streamer/mjpg-streamer-experimental/docker-start.sh"]
 
-CMD ["input_uvc.so"]
+# Enter the values for input and output options of the stream
+# If no options are provided, default values are passed
+
+CMD ["output_http.so -w ./www","input_uvc.so"]

--- a/mjpg-streamer-experimental/docker-compose.yml
+++ b/mjpg-streamer-experimental/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  mjpg-streamer:
+    restart: always
+    # update to tag used to create image
+    container_name: mjpg-streamer
+    image: mjpg-streamer
+    devices:
+      - /dev/video0:/dev/video0
+    ports:
+      - 8080:8080
+
+# docker-start.sh default output and input arguments
+# ensure each argument string is present and input with quotes
+# don't change the command input order
+
+    command:
+      - "output_http.so -w ./www"
+      - "input_uvc.so"
+
+      # example command updates
+      
+      # - "output_http.so -w ./www -c admin:admin"
+      # - "input_uvc.so -r 1920x1080"


### PR DESCRIPTION
1. **Dockerfile change** - I updated the `ENTRYPOINT` to remove the hard-coded output argument of `output_http.so -w ./www` and added it to the `CMD` input. 
    
    - The update allows users to update stream parameters using command arguments as part of their docker call. Previously, users could not adjust output arguments without mapping a volume to their container.
    
    - Updated file path: `./mjpg-streamer/mjpg-streamer-experimental/Dockerfile`

2. **Example Docker Compose** - Added an example `docker-compose.yml` to illustrate how to configure a container using an image built with the `Dockerfile`

3. **Updated README** - Added a new Docker section, which outlines how users can:

    1. Build an `mjpg-streamer` image using provided Dockerfile
    2. Create a container from the image using `docker run`
    3. Create a container from the image using `docker compose`