### PR TITLE
input_uvc: fix 'undefined symbol: resolutions_help'

### DIFF
--- a/mjpg-streamer-experimental/CMakeLists.txt
+++ b/mjpg-streamer-experimental/CMakeLists.txt
@@ -92,6 +92,7 @@ set (CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 add_executable(mjpg_streamer mjpg_streamer.c
                              utils.c)
 
+set_property(TARGET mjpg_streamer PROPERTY ENABLE_EXPORTS ON)
 target_link_libraries(mjpg_streamer pthread dl)
 install(TARGETS mjpg_streamer DESTINATION bin)
 


### PR DESCRIPTION
Fixes runtime error:
```  
dlopen: /usr/lib/mjpg-streamer/input_uvc.so: undefined symbol: resolutions_help
```
Source: http://lists.busybox.net/pipermail/buildroot/2024-August/759732.html