### PR TITLE
Add input_haiku_media plugin: Haiku OS UVC webcam via BubiCam's WebcamKit

### DIFF
--- a/mjpg-streamer-experimental/CMakeLists.txt
+++ b/mjpg-streamer-experimental/CMakeLists.txt
@@ -1,7 +1,10 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
 project("mjpg-streamer" C)
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  include_directories(BEFORE ${CMAKE_SOURCE_DIR}/compat)
+endif()
 
 # If the user doesn't manually specify a build type, use 'Release'
 message("CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
@@ -93,7 +96,11 @@ set (CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 add_executable(mjpg_streamer mjpg_streamer.c
                              utils.c)
 
-target_link_libraries(mjpg_streamer pthread dl)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  target_link_libraries(mjpg_streamer pthread dl)
+else()
+  target_link_libraries(mjpg_streamer pthread)
+endif()
 install(TARGETS mjpg_streamer DESTINATION bin)
 
 #

--- a/mjpg-streamer-experimental/CMakeLists.txt
+++ b/mjpg-streamer-experimental/CMakeLists.txt
@@ -62,6 +62,7 @@ add_subdirectory(plugins/input_opencv)
 add_subdirectory(plugins/input_raspicam)
 add_subdirectory(plugins/input_ptp2)
 add_subdirectory(plugins/input_uvc)
+add_subdirectory(plugins/input_haiku_media)
 
 #
 # Output plugins

--- a/mjpg-streamer-experimental/README.md
+++ b/mjpg-streamer-experimental/README.md
@@ -40,3 +40,31 @@ Output plugins:
 * ~output_udp~ (not functional)
 * output_viewer ([documentation](plugins/output_viewer/README.md))
 
+
+Building on Haiku
+=================
+
+mjpg-streamer can be built on [Haiku OS](https://www.haiku-os.org/) with the following notes:
+
+**What works on Haiku:**
+- Core streamer binary (`mjpg_streamer`)
+- `input_http` plugin
+- `output_file`, `output_http`, `output_rtsp`, `output_udp` plugins
+
+**What is not available on Haiku (Linux-only):**
+- `input_uvc` — requires Video4Linux2 (`linux/videodev2.h`)
+- `input_file` — requires `sys/inotify.h`
+- `input_raspicam` — Raspberry Pi specific
+- `output_viewer` — requires SDL
+- `output_zmqserver` — requires ZeroMQ
+
+**Fixes applied for Haiku compatibility:**
+- Updated `cmake_minimum_required` to VERSION 3.5 (required by modern CMake)
+- Added `compat/linux/` shim headers providing `linux/types.h`, `linux/videodev2.h`, and `linux/version.h` for non-Linux platforms
+- Fixed `utils.c`: replaced `<wait.h>` with `<sys/wait.h>`, removed `<linux/stat.h>`
+- Removed `-ldl` linker flag on non-Linux (Haiku's dynamic linking is built into libroot)
+
+**Build:**
+
+    mkdir _build && cd _build && cmake -DCMAKE_BUILD_TYPE=Release .. && make
+

--- a/mjpg-streamer-experimental/README.md
+++ b/mjpg-streamer-experimental/README.md
@@ -26,6 +26,7 @@ Input plugins:
 
 * input_file
 * input_http
+* input_haiku_media ([documentation](plugins/input_haiku_media/README.md))
 * input_opencv ([documentation](plugins/input_opencv/README.md))
 * input_ptp2
 * input_raspicam ([documentation](plugins/input_raspicam/README.md))

--- a/mjpg-streamer-experimental/README_ja.md
+++ b/mjpg-streamer-experimental/README_ja.md
@@ -1,0 +1,47 @@
+mjpg-streamer
+=============
+
+現在、既知の問題はありませんが、このソフトウェアはまだ若く、広く使用されていないため、問題が発生する可能性があります。このソフトウェアを使用する場合は、実際に何をしているのか理解している必要があります。ソフトウェアを使用する場合、ソースコードが期待通りに動作するかを確認し、使用するリスクは自己責任となります。
+
+
+使用方法
+=====
+
+mjpg-streamerを起動する際、1つ以上の入力プラグインと1つの出力プラグインを指定します。例えば、V4L互換のウェブカメラをHTTPサーバー経由でストリーミングする場合（最も一般的な使用例）、次のようにできます：
+
+	mjpg_streamer -i input_uvc.so -o output_http.so
+
+各プラグインは様々なオプションをサポートしており、プラグインの`--help`オプションを使用してオプションを確認できます：
+
+	mjpg_streamer -i 'input_uvc.so --help'
+
+
+その他の例はstart.shバッシュスクリプトで確認できます。
+
+プラグインのドキュメント
+====================
+
+入力プラグイン：
+
+* input_file
+* input_http
+* input_opencv ([ドキュメント](plugins/input_opencv/README.md))
+* input_ptp2
+* input_raspicam ([ドキュメント](plugins/input_raspicam/README.md))
+* input_uvc ([ドキュメント](plugins/input_uvc/README.md))
+
+出力プラグイン：
+
+* output_file
+* output_http ([ドキュメント](plugins/output_http/README.md))
+* ~output_rtsp~ (機能しません)
+* ~output_udp~ (機能しません)
+* output_viewer ([ドキュメント](plugins/output_viewer/README.md))
+
+コントロール画面の日本語化
+====================
+
+Webインターフェースは通常英語で表示されますが、コントロール画面のみ日本語版（control_ja.htm）も利用できるようにしました。
+「コントロール」のリンクをクリックすれば、カメラの設定項目や選択肢が日本語で表示されます。
+
+翻訳はクライアントサイドで実装されているため、新たなコントロール項目を日本語化したい場合は、翻訳辞書に対応する日本語訳を追加するだけで対応できます。

--- a/mjpg-streamer-experimental/README_ja.md
+++ b/mjpg-streamer-experimental/README_ja.md
@@ -25,6 +25,7 @@ mjpg-streamerを起動する際、1つ以上の入力プラグインと1つの�
 
 * input_file
 * input_http
+* input_haiku_media ([ドキュメント](plugins/input_haiku_media/README.md))
 * input_opencv ([ドキュメント](plugins/input_opencv/README.md))
 * input_ptp2
 * input_raspicam ([ドキュメント](plugins/input_raspicam/README.md))

--- a/mjpg-streamer-experimental/README_ja.md
+++ b/mjpg-streamer-experimental/README_ja.md
@@ -46,3 +46,30 @@ Webインターフェースは通常英語で表示されますが、コント�
 「コントロール」のリンクをクリックすれば、カメラの設定項目や選択肢が日本語で表示されます。
 
 翻訳はクライアントサイドで実装されているため、新たなコントロール項目を日本語化したい場合は、翻訳辞書に対応する日本語訳を追加するだけで対応できます。
+Haikuでのビルド
+=================
+
+mjpg-streamerは [Haiku OS](https://www.haiku-os.org/) でビルドできます。
+
+**Haikuで動作するもの：**
+- コアバイナリ（`mjpg_streamer`）
+- `input_http` プラグイン
+- `output_file`、`output_http`、`output_rtsp`、`output_udp` プラグイン
+
+**Haikuで利用できないもの（Linux専用）：**
+- `input_uvc` — Video4Linux2（`linux/videodev2.h`）が必要
+- `input_file` — `sys/inotify.h` が必要
+- `input_raspicam` — Raspberry Pi専用
+- `output_viewer` — SDL が必要
+- `output_zmqserver` — ZeroMQ が必要
+
+**Haiku対応のために行った修正：**
+- `cmake_minimum_required` を VERSION 3.5 に更新（新しいCMakeで必須）
+- `compat/linux/` に互換シムヘッダを追加（`linux/types.h`、`linux/videodev2.h`、`linux/version.h`）
+- `utils.c` の修正：`<wait.h>` を `<sys/wait.h>` に変更、`<linux/stat.h>` を削除
+- 非Linuxプラットフォームで `-ldl` リンクフラグを除去（HaikuはlibRootに動的リンク機能が内蔵）
+
+**ビルド方法：**
+
+    mkdir _build && cd _build && cmake -DCMAKE_BUILD_TYPE=Release .. && make
+

--- a/mjpg-streamer-experimental/compat/linux/types.h
+++ b/mjpg-streamer-experimental/compat/linux/types.h
@@ -1,0 +1,18 @@
+#ifndef _COMPAT_LINUX_TYPES_H
+#define _COMPAT_LINUX_TYPES_H
+#include <stdint.h>
+typedef uint8_t  __u8;
+typedef uint16_t __u16;
+typedef uint32_t __u32;
+typedef uint64_t __u64;
+typedef int8_t   __s8;
+typedef int16_t  __s16;
+typedef int32_t  __s32;
+typedef int64_t  __s64;
+typedef uint16_t __le16;
+typedef uint32_t __le32;
+typedef uint64_t __le64;
+typedef uint16_t __be16;
+typedef uint32_t __be32;
+typedef uint64_t __be64;
+#endif

--- a/mjpg-streamer-experimental/compat/linux/version.h
+++ b/mjpg-streamer-experimental/compat/linux/version.h
@@ -1,0 +1,5 @@
+#ifndef _COMPAT_LINUX_VERSION_H
+#define _COMPAT_LINUX_VERSION_H
+#define KERNEL_VERSION(a,b,c) (((a) << 16) + ((b) << 8) + (c))
+#define LINUX_VERSION_CODE KERNEL_VERSION(3,0,0)
+#endif

--- a/mjpg-streamer-experimental/compat/linux/videodev2.h
+++ b/mjpg-streamer-experimental/compat/linux/videodev2.h
@@ -1,0 +1,71 @@
+#ifndef _COMPAT_LINUX_VIDEODEV2_H
+#define _COMPAT_LINUX_VIDEODEV2_H
+/* Minimal V4L2 compatibility shim for non-Linux platforms (e.g., Haiku) */
+#include <linux/types.h>
+
+#define V4L2_CTRL_CLASS_USER  0x00980000
+#define V4L2_CTRL_TYPE_INTEGER    1
+#define V4L2_CTRL_TYPE_BOOLEAN    2
+#define V4L2_CTRL_TYPE_MENU       3
+#define V4L2_CTRL_TYPE_BUTTON     4
+#define V4L2_CTRL_TYPE_INTEGER64  5
+#define V4L2_CTRL_TYPE_CTRL_CLASS 6
+#define V4L2_CTRL_TYPE_STRING     7
+
+#define V4L2_CTRL_FLAG_DISABLED   0x0001
+#define V4L2_CTRL_FLAG_GRABBED    0x0002
+#define V4L2_CTRL_FLAG_READ_ONLY  0x0004
+#define V4L2_CTRL_FLAG_UPDATE     0x0008
+#define V4L2_CTRL_FLAG_INACTIVE   0x0010
+#define V4L2_CTRL_FLAG_SLIDER     0x0020
+#define V4L2_CTRL_FLAG_WRITE_ONLY 0x0040
+
+#define V4L2_BUF_TYPE_VIDEO_CAPTURE 1
+
+#define V4L2_PIX_FMT_MJPEG  0x47504a4d
+#define V4L2_PIX_FMT_JPEG   0x4745504a
+#define V4L2_PIX_FMT_YUYV   0x56595559
+#define V4L2_PIX_FMT_RGB24  0x33424752
+
+struct v4l2_queryctrl {
+    __u32 id;
+    __u32 type;
+    __u8  name[32];
+    __s32 minimum;
+    __s32 maximum;
+    __s32 step;
+    __s32 default_value;
+    __u32 flags;
+    __u32 reserved[2];
+};
+
+struct v4l2_querymenu {
+    __u32 id;
+    __u32 index;
+    union {
+        __u8  name[32];
+        __s64 value;
+    };
+    __u32 reserved;
+} __attribute__((packed));
+
+struct v4l2_fmtdesc {
+    __u32 index;
+    __u32 type;
+    __u32 flags;
+    __u8  description[32];
+    __u32 pixelformat;
+    __u32 reserved[4];
+};
+
+struct v4l2_jpegcompression {
+    int quality;
+    int  APPn;
+    int  APP_len;
+    char APP_data[60];
+    int  COM_len;
+    char COM_data[60];
+    __u32 jpeg_markers;
+};
+
+#endif /* _COMPAT_LINUX_VIDEODEV2_H */

--- a/mjpg-streamer-experimental/plugins/input_haiku_media/CMakeLists.txt
+++ b/mjpg-streamer-experimental/plugins/input_haiku_media/CMakeLists.txt
@@ -1,14 +1,20 @@
 cmake_minimum_required(VERSION 3.5)
 enable_language(CXX)
 
-# input_haiku_media.so — Haiku-only Media Kit video input plugin
+# input_haiku_media.so — Haiku-only Media Kit video input plugin.
+# Bridges to BubiCam's WebcamKit (WebcamRoster/WebcamDevice) rather than
+# talking to the Media Kit directly - see BUBICAM_DIR below.
 if(CMAKE_SYSTEM_NAME STREQUAL "Haiku")
     find_library(MEDIA_LIB       media)
     find_library(TRANSLATION_LIB translation)
     find_library(BE_LIB          be)
 
-    if(MEDIA_LIB AND TRANSLATION_LIB AND BE_LIB)
-        message(STATUS " + input_haiku_media  (Haiku Media Kit)")
+    set(BUBICAM_DIR "$ENV{HOME}/git/BubiCam")
+    set(WEBCAM_LIB_DIR "${BUBICAM_DIR}/lib/libwebcam/objects.x86_64-cc13-release")
+    find_library(WEBCAM_LIB webcam PATHS "${WEBCAM_LIB_DIR}" NO_DEFAULT_PATH)
+
+    if(MEDIA_LIB AND TRANSLATION_LIB AND BE_LIB AND WEBCAM_LIB)
+        message(STATUS " + input_haiku_media  (Haiku Media Kit, via BubiCam WebcamKit)")
 
         add_library(input_haiku_media SHARED input_haiku_media.cpp)
 
@@ -16,14 +22,18 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Haiku")
             PREFIX ""
             SUFFIX ".so"
             CXX_STANDARD 11
+            BUILD_RPATH "${WEBCAM_LIB_DIR}"
         )
 
         target_include_directories(input_haiku_media PRIVATE
             ${CMAKE_SOURCE_DIR}
             ${CMAKE_SOURCE_DIR}/plugins
+            "${BUBICAM_DIR}/lib/libwebcam/include"
+            "${BUBICAM_DIR}/src/webcam"
         )
 
         target_link_libraries(input_haiku_media
+            ${WEBCAM_LIB}
             ${MEDIA_LIB}
             ${TRANSLATION_LIB}
             ${BE_LIB}
@@ -33,6 +43,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Haiku")
             LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}
         )
     else()
-        message(STATUS " - input_haiku_media  (missing: media=${MEDIA_LIB} translation=${TRANSLATION_LIB} be=${BE_LIB})")
+        message(STATUS " - input_haiku_media  (missing: media=${MEDIA_LIB} translation=${TRANSLATION_LIB} be=${BE_LIB} webcam=${WEBCAM_LIB})")
     endif()
 endif()

--- a/mjpg-streamer-experimental/plugins/input_haiku_media/CMakeLists.txt
+++ b/mjpg-streamer-experimental/plugins/input_haiku_media/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.5)
+enable_language(CXX)
+
+# input_haiku_media.so — Haiku-only Media Kit video input plugin
+if(CMAKE_SYSTEM_NAME STREQUAL "Haiku")
+    find_library(MEDIA_LIB       media)
+    find_library(TRANSLATION_LIB translation)
+    find_library(BE_LIB          be)
+
+    if(MEDIA_LIB AND TRANSLATION_LIB AND BE_LIB)
+        message(STATUS " + input_haiku_media  (Haiku Media Kit)")
+
+        add_library(input_haiku_media SHARED input_haiku_media.cpp)
+
+        set_target_properties(input_haiku_media PROPERTIES
+            PREFIX ""
+            SUFFIX ".so"
+            CXX_STANDARD 11
+        )
+
+        target_include_directories(input_haiku_media PRIVATE
+            ${CMAKE_SOURCE_DIR}
+            ${CMAKE_SOURCE_DIR}/plugins
+        )
+
+        target_link_libraries(input_haiku_media
+            ${MEDIA_LIB}
+            ${TRANSLATION_LIB}
+            ${BE_LIB}
+        )
+
+        install(TARGETS input_haiku_media
+            LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}
+        )
+    else()
+        message(STATUS " - input_haiku_media  (missing: media=${MEDIA_LIB} translation=${TRANSLATION_LIB} be=${BE_LIB})")
+    endif()
+endif()

--- a/mjpg-streamer-experimental/plugins/input_haiku_media/README.md
+++ b/mjpg-streamer-experimental/plugins/input_haiku_media/README.md
@@ -1,0 +1,57 @@
+# input_haiku_media
+
+Haiku OS 専用の mjpg-streamer 入力プラグインです。  
+Haiku の Media Kit (BMediaRoster) を通じて `haiku-uvc-webcam` メディアサーバーアドオンに接続し、USB ウェブカメラのフレームを JPEG にエンコードしてストリーミングします。
+
+## 概要 / Overview
+
+Haiku には V4L2 が存在しないため、mjpg-streamer の既存 `input_uvc` プラグインは動作しません。  
+このプラグインは Haiku の Media Kit を使い、`haiku-uvc-webcam` が公開している B_RGB32 フレームを受け取り、Translation Kit で JPEG へ変換します。
+
+## 必要条件 / Requirements
+
+- **OS**: Haiku R1 Beta 4 以降
+- **メディアアドオン**: [`haiku-uvc-webcam`](https://github.com/lamat/haiku-uvc-webcam) がインストール済みで `media_server` に組み込まれていること
+- **ビルドツール**: gcc 13+, cmake 3.x
+
+## ビルド / Build
+
+```sh
+cd mjpg-streamer-experimental
+mkdir -p _build && cd _build
+cmake ..
+make input_haiku_media
+```
+
+## 使い方 / Usage
+
+```sh
+cd mjpg-streamer-experimental/_build
+./mjpg_streamer \
+    -i "./plugins/input_haiku_media/input_haiku_media.so" \
+    -o "./plugins/output_http/output_http.so -w ./www"
+```
+
+ブラウザで `http://<HaikuのIP>:8080/?action=stream` を開くとストリームを確認できます。
+
+### オプション
+
+| オプション | 説明 | デフォルト |
+|-----------|------|-----------|
+| `-d <node_name>` | 接続するメディアノード名 | (最初に見つかったビデオプロデューサー) |
+| `-f <fps>` | フレームレート | 30 |
+| `-q <quality>` | JPEG 品質 (1–100) | 80 |
+
+## 仕組み / How it works
+
+1. `BApplication` を初期化して Media Kit を有効化
+2. `BMediaRoster` で `haiku-uvc-webcam` ノードを検索
+3. `MjpgConsumer` (`BBufferConsumer` + `BMediaEventLooper`) を生成・接続
+4. 受信した B_RGB32 バッファを `BBitmap` + `BTranslatorRoster` で JPEG へエンコード
+5. mjpg-streamer の共有バッファ (`pglobal->in[id].buf`) に格納してストリーミング
+
+## 注意事項 / Notes
+
+- B_RGB32 は Haiku では BGRA バイト順です（Translation Kit が自動処理します）
+- `haiku-uvc-webcam` アドオンは `media_server` に登録されている必要があります  
+  (`media_server &` で起動後、アドオンを `/boot/home/config/non-packaged/add-ons/media/` に配置してください)

--- a/mjpg-streamer-experimental/plugins/input_haiku_media/README.md
+++ b/mjpg-streamer-experimental/plugins/input_haiku_media/README.md
@@ -1,27 +1,52 @@
 # input_haiku_media
 
-Haiku OS 専用の mjpg-streamer 入力プラグインです。  
-Haiku の Media Kit (BMediaRoster) を通じて `haiku-uvc-webcam` メディアサーバーアドオンに接続し、USB ウェブカメラのフレームを JPEG にエンコードしてストリーミングします。
+Haiku OS 専用の mjpg-streamer 入力プラグインです。
+BubiCam の [`WebcamKit`](https://github.com/atomozero/BubiCam) ライブラリ (`libwebcam.so`) を
+経由して USB ウェブカメラのフレームを取得し、JPEG にエンコードしてストリーミングします。
 
 ## 概要 / Overview
 
-Haiku には V4L2 が存在しないため、mjpg-streamer の既存 `input_uvc` プラグインは動作しません。  
-このプラグインは Haiku の Media Kit を使い、`haiku-uvc-webcam` が公開している B_RGB32 フレームを受け取り、Translation Kit で JPEG へ変換します。
+Haiku には V4L2 が存在しないため、mjpg-streamer の既存 `input_uvc` プラグインは動作しません。
+
+このプラグインは以前、Haiku の Media Kit (`BMediaRoster`) を自前で叩いて
+`haiku-uvc-webcam` アドオンに直接接続していましたが、ノード登録〜接続の
+ハンドシェイク中にカーネルパニックを再現性高く引き起こすことが分かりました
+(おそらく `BMediaEventLooper` の配線漏れ — `NodeRegistered()`/`Run()` が
+無く、ノード自身の制御スレッドが起動していなかったため)。
+
+現在は、同じ webcam 接続処理を安定して実行できている BubiCam の
+`WebcamKit` (`WebcamRoster` / `WebcamDevice` / `VideoConsumer`) を
+`libwebcam.so` としてリンクし、その上に薄いブリッジを被せる方式に
+書き換えています。プラグイン自身が行うのは、デバイスの列挙、
+`WebcamDevice::StartCapture()` の呼び出し、受信した `BBitmap` フレームの
+JPEG エンコードと mjpg-streamer の共有バッファへの書き込みだけです。
 
 ## 必要条件 / Requirements
 
 - **OS**: Haiku R1 Beta 4 以降
-- **メディアアドオン**: [`haiku-uvc-webcam`](https://github.com/lamat/haiku-uvc-webcam) がインストール済みで `media_server` に組み込まれていること
+- **BubiCam**: このリポジトリと同じ階層(`../../BubiCam`、既定では
+  `~/git/BubiCam`)に [`BubiCam`](https://github.com/atomozero/BubiCam) を
+  clone してビルド済みであること(`lib/libwebcam/objects.x86_64-cc13-release/libwebcam.so`
+  が存在している必要があります)
+- **メディアアドオン**: [`haiku-uvc-webcam`](https://github.com/lamat/haiku-uvc-webcam) が
+  インストール済みで `media_server` に組み込まれていること(WebcamKit が内部で使用します)
 - **ビルドツール**: gcc 13+, cmake 3.x
 
 ## ビルド / Build
 
 ```sh
-cd mjpg-streamer-experimental
+# 先に BubiCam 側の libwebcam.so をビルドしておく
+cd ~/git/BubiCam/lib/libwebcam && make
+
+cd ~/git/mjpg-streamer/mjpg-streamer-experimental
 mkdir -p _build && cd _build
 cmake ..
 make input_haiku_media
 ```
+
+`libwebcam` が見つからない場合、cmake の出力に
+`- input_haiku_media  (missing: ... webcam=WEBCAM_LIB-NOTFOUND)`
+と表示され、このプラグインはビルド対象から外れます。
 
 ## 使い方 / Usage
 
@@ -29,29 +54,37 @@ make input_haiku_media
 cd mjpg-streamer-experimental/_build
 ./mjpg_streamer \
     -i "./plugins/input_haiku_media/input_haiku_media.so" \
-    -o "./plugins/output_http/output_http.so -w ./www"
+    -o "./plugins/output_http/output_http.so -p 8090"
 ```
 
-ブラウザで `http://<HaikuのIP>:8080/?action=stream` を開くとストリームを確認できます。
+ブラウザで `http://<HaikuのIP>:8090/?action=stream` を開くとストリームを、
+`http://<HaikuのIP>:8090/?action=snapshot` で単発の JPEG を確認できます。
 
 ### オプション
 
 | オプション | 説明 | デフォルト |
 |-----------|------|-----------|
-| `-d <node_name>` | 接続するメディアノード名 | (最初に見つかったビデオプロデューサー) |
-| `-f <fps>` | フレームレート | 30 |
-| `-q <quality>` | JPEG 品質 (1–100) | 80 |
+| `-d <node_name>` | 接続するデバイス名(部分一致) | (最初に見つかったウェブカメラ) |
+
+解像度・フレームレート・JPEG品質は `WebcamDevice` 側の自動ネゴシエーションに
+委ねており、このプラグインからは指定できません。
 
 ## 仕組み / How it works
 
 1. `BApplication` を初期化して Media Kit を有効化
-2. `BMediaRoster` で `haiku-uvc-webcam` ノードを検索
-3. `MjpgConsumer` (`BBufferConsumer` + `BMediaEventLooper`) を生成・接続
-4. 受信した B_RGB32 バッファを `BBitmap` + `BTranslatorRoster` で JPEG へエンコード
-5. mjpg-streamer の共有バッファ (`pglobal->in[id].buf`) に格納してストリーミング
+2. `WebcamRoster::EnumerateDevices()` でウェブカメラを列挙し、1台選択
+3. mjpg-streamer 用の小さな `BLooper` (`MjpgLooper`) を起動
+4. `WebcamDevice::StartCapture(looper)` を呼び出し、以降 `MjpgLooper` に
+   `MSG_WEBCAM_FRAME` メッセージで `BBitmap` フレームが届く
+5. 受信した `BBitmap` を `BTranslatorRoster` で JPEG へエンコード
+6. mjpg-streamer の共有バッファ (`pglobal->in[id].buf`) に格納してストリーミング
+
+デバイス検出・ノード接続・バッファグループの管理など、クラッシュの原因に
+なりやすい低レベルの Media Kit 処理はすべて BubiCam 側の実装に任せています。
 
 ## 注意事項 / Notes
 
-- B_RGB32 は Haiku では BGRA バイト順です（Translation Kit が自動処理します）
-- `haiku-uvc-webcam` アドオンは `media_server` に登録されている必要があります  
-  (`media_server &` で起動後、アドオンを `/boot/home/config/non-packaged/add-ons/media/` に配置してください)
+- 映像品質(乱れ・ティアリング)は USB 帯域不足による isochronous 転送の
+  問題であり、このプラグイン固有の不具合ではありません
+- `libwebcam.so` の実行時ロードには `BUILD_RPATH` を利用しているため、
+  `LD_LIBRARY_PATH` の設定なしにビルドディレクトリからそのまま実行できます

--- a/mjpg-streamer-experimental/plugins/input_haiku_media/input_haiku_media.cpp
+++ b/mjpg-streamer-experimental/plugins/input_haiku_media/input_haiku_media.cpp
@@ -1,12 +1,15 @@
 /*
  * input_haiku_media.cpp — mjpg-streamer input plugin using Haiku Media Kit
  *
- * Connects to a live video producer node (e.g. haiku-uvc-webcam add-on)
- * via BMediaRoster, receives B_RGB32 frames, encodes to JPEG, and feeds
- * them into mjpg-streamer's shared frame buffer.
+ * Thin bridge to BubiCam's WebcamKit (WebcamRoster/WebcamDevice), which
+ * already implements a proven, crash-free capture pipeline (BMediaEventLooper
+ * based consumer, buffer group setup, dormant-node instantiation, etc.).
+ * This plugin only has to: enumerate a device, start capture into a small
+ * BLooper, and JPEG-encode + publish each received frame.
  *
- * Build:  CMakeLists.txt in this directory (Haiku only)
- * Usage:  mjpg_streamer -i "input_haiku_media.so [-r WxH] [-d node_name]"
+ * Build:  CMakeLists.txt in this directory (Haiku only) links libwebcam.so
+ *         from the sibling BubiCam checkout.
+ * Usage:  mjpg_streamer -i "input_haiku_media.so [-d node_name]"
  *                        -o "output_http.so"
  */
 
@@ -16,18 +19,17 @@
 #include <Application.h>
 #include <Bitmap.h>
 #include <BitmapStream.h>
-#include <Buffer.h>
-#include <BufferConsumer.h>
 #include <DataIO.h>
-#include <MediaDefs.h>
-#include <MediaEventLooper.h>
-#include <MediaFormats.h>
-#include <MediaRoster.h>
 #include <OS.h>
 #include <TranslatorRoster.h>
+#include <TranslatorFormats.h>
+
+// BubiCam's WebcamKit
+#include <WebcamKit.h>
 
 // ── C headers ───────────────────────────────────────────────────────────────
 #include <errno.h>
+#include <getopt.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -36,438 +38,245 @@
 #include <pthread.h>
 
 // ── mjpg-streamer interface ─────────────────────────────────────────────────
-// Include via root header to avoid double-include of plugins/input.h
 extern "C" {
 #include "mjpg_streamer.h"
+#include "utils.h"
 }
 
 // ── Plugin bookkeeping ──────────────────────────────────────────────────────
 #define PLUGIN_NAME "input_haiku_media"
-// Override the generic LOG macro with our prefixed version
 #undef LOG
 #define LOG(fmt, ...) \
     fprintf(stderr, "[" PLUGIN_NAME "] " fmt "\n", ##__VA_ARGS__)
 
-static globals *pglobal = NULL;   /* set in input_init */
+static globals *pglobal = NULL;
+static BApplication *gApp = NULL;
 
-// ── Shared plugin state ─────────────────────────────────────────────────────
 struct plugin_ctx {
     int            id;
-    int            width;
-    int            height;
-    char           node_name[256]; /* optional: filter by name */
+    char           node_name[256]; /* optional: filter by device name */
     volatile bool  running;
     thread_id      setup_tid;
-    /* filled by setup thread once connected */
-    media_node     producer_node;
-    media_output   prod_out;
-    media_input    cons_in;
-    bool           connected;
 };
 
-static plugin_ctx    *ctx       = NULL;
-static BApplication  *gApp      = NULL;  /* created if be_app is NULL */
-
-// forward declaration
-class MjpgConsumer;
-static MjpgConsumer  *gConsumer = NULL;
+static plugin_ctx gCtx;
 
 // ══════════════════════════════════════════════════════════════════════════════
-// MjpgConsumer: BBufferConsumer + BMediaEventLooper
+// JPEG encode + publish into mjpg-streamer's shared buffer
 // ══════════════════════════════════════════════════════════════════════════════
-class MjpgConsumer : public BBufferConsumer, public BMediaEventLooper {
-public:
-    explicit MjpgConsumer(plugin_ctx *c);
-    ~MjpgConsumer() override {}
-
-    /* BMediaNode */
-    BMediaAddOn *AddOn(int32 *) const override { return NULL; }
-
-    /* BBufferConsumer */
-    status_t AcceptFormat(const media_destination &dest,
-                          media_format *fmt) override;
-    status_t GetNextInput(int32 *cookie, media_input *out) override;
-    void     BufferReceived(BBuffer *buffer) override;
-    void     DisposeInputCookie(int32) override {}
-    void     ProducerDataStatus(const media_destination &,
-                                int32, bigtime_t) override {}
-    status_t GetLatencyFor(const media_destination &,
-                           bigtime_t *latency,
-                           media_node_id *) override
-    {
-        *latency = 5000LL; /* 5 ms */
-        return B_OK;
-    }
-    status_t Connected(const media_source &src,
-                       const media_destination &dest,
-                       const media_format &fmt,
-                       media_input *out_input) override;
-    void     Disconnected(const media_source &,
-                          const media_destination &) override;
-    status_t FormatChanged(const media_source &,
-                           const media_destination &,
-                           int32,
-                           const media_format &) override { return B_OK; }
-
-    /* BMediaEventLooper */
-    void HandleEvent(const media_timed_event *,
-                     bigtime_t, bool) override {}
-
-    media_input &Input() { return fInput; }
-
-    /* Public wrappers for protected Run()/Quit() */
-    void StartLooper() { Run(); }
-    void StopLooper()  { Quit(); }
-
-private:
-    void EncodeAndPublish(uint8 *rgb32, int w, int h);
-
-    plugin_ctx *fCtx;
-    media_input fInput;
-    bool        fConnected;
-};
-
-// ── Constructor ─────────────────────────────────────────────────────────────
-MjpgConsumer::MjpgConsumer(plugin_ctx *c)
-    : BMediaNode("mjpg-haiku-consumer"),
-      BBufferConsumer(B_MEDIA_RAW_VIDEO),
-      BMediaEventLooper(),
-      fCtx(c),
-      fConnected(false)
+static void
+EncodeAndPublish(int id, BBitmap *bitmap)
 {
-    fInput.destination.port = ControlPort();
-    fInput.destination.id   = 0;
-    fInput.node             = Node();
-    fInput.source           = media_source::null;
-    strlcpy(fInput.name, "Video In", sizeof(fInput.name));
-}
-
-// ── AcceptFormat ─────────────────────────────────────────────────────────────
-status_t
-MjpgConsumer::AcceptFormat(const media_destination &, media_format *fmt)
-{
-    if (fmt->type != B_MEDIA_RAW_VIDEO &&
-        fmt->type != B_MEDIA_UNKNOWN_TYPE)
-        return B_MEDIA_BAD_FORMAT;
-
-    fmt->type = B_MEDIA_RAW_VIDEO;
-    fmt->u.raw_video.display.format = B_RGB32;
-    return B_OK;
-}
-
-// ── GetNextInput ─────────────────────────────────────────────────────────────
-status_t
-MjpgConsumer::GetNextInput(int32 *cookie, media_input *out)
-{
-    if (*cookie != 0)
-        return B_BAD_INDEX;
-    *out = fInput;
-    (*cookie)++;
-    return B_OK;
-}
-
-// ── Connected ────────────────────────────────────────────────────────────────
-status_t
-MjpgConsumer::Connected(const media_source &src,
-                        const media_destination &,
-                        const media_format &fmt,
-                        media_input *out_input)
-{
-    fInput.source = src;
-    fInput.format = fmt;
-    *out_input    = fInput;
-    fConnected    = true;
-
-    /* update dimensions from negotiated format */
-    uint32 w = fmt.u.raw_video.display.line_width;
-    uint32 h = fmt.u.raw_video.display.line_count;
-    if (w > 0) fCtx->width  = (int)w;
-    if (h > 0) fCtx->height = (int)h;
-    LOG("Connected: %dx%d B_RGB32", fCtx->width, fCtx->height);
-    return B_OK;
-}
-
-// ── Disconnected ─────────────────────────────────────────────────────────────
-void
-MjpgConsumer::Disconnected(const media_source &, const media_destination &)
-{
-    fConnected    = false;
-    fInput.source = media_source::null;
-    LOG("Disconnected");
-}
-
-// ── EncodeAndPublish: B_RGB32 → JPEG → pglobal ──────────────────────────────
-void
-MjpgConsumer::EncodeAndPublish(uint8 *rgb32, int w, int h)
-{
-    /* Wrap raw pixels in a BBitmap (B_RGB32 = BGRA byte order on Haiku) */
-    BBitmap *bm = new BBitmap(BRect(0, 0, w - 1, h - 1), B_RGB32);
-    if (!bm || bm->InitCheck() != B_OK) {
-        delete bm;
+    if (!pglobal || bitmap == NULL)
         return;
-    }
-    size_t sz = (size_t)(w * h * 4);
-    memcpy(bm->Bits(), rgb32, sz);
 
-    /* Encode to JPEG via the Translation Kit (JPEG Translator must be installed) */
-    BBitmapStream bs(bm);   /* bs takes ownership of bm */
-    BMallocIO     jpegBuf;
+    /* BBitmapStream takes ownership of 'bitmap' and deletes it on
+       destruction - caller must not delete it separately. */
+    BBitmapStream bitmapStream(bitmap);
+    BMallocIO jpegOut;
 
-    BTranslatorRoster *roster = BTranslatorRoster::Default();
-    status_t err = roster->Translate(&bs, NULL, NULL, &jpegBuf, B_JPEG_FORMAT);
-
-    /* detach so bs destructor doesn't double-free */
-    BBitmap *detached = NULL;
-    bs.DetachBitmap(&detached);
-    delete detached;
+    status_t err = BTranslatorRoster::Default()->Translate(
+        &bitmapStream, NULL, NULL, &jpegOut, B_JPEG_FORMAT);
 
     if (err != B_OK) {
-        LOG("JPEG translation error: %s", strerror(err));
+        LOG("JPEG translate failed: %s", strerror(err));
         return;
     }
 
-    size_t  jpegSz   = jpegBuf.BufferLength();
-    uint8  *jpegData = (uint8 *)malloc(jpegSz);
-    if (!jpegData) return;
-    memcpy(jpegData, jpegBuf.Buffer(), jpegSz);
+    const void *jpegData = jpegOut.Buffer();
+    size_t      jpegSize = jpegOut.BufferLength();
 
-    /* publish to mjpg-streamer */
-    int id = fCtx->id;
+    if (!jpegData || jpegSize == 0)
+        return;
+
     pthread_mutex_lock(&pglobal->in[id].db);
-    free(pglobal->in[id].buf);
-    pglobal->in[id].buf  = jpegData;
-    pglobal->in[id].size = (int)jpegSz;
-    gettimeofday(&pglobal->in[id].timestamp, NULL);
+
+    if (pglobal->in[id].buf != NULL)
+        free(pglobal->in[id].buf);
+
+    pglobal->in[id].buf = (unsigned char *)malloc(jpegSize);
+    if (pglobal->in[id].buf == NULL) {
+        pglobal->in[id].size = 0;
+        pthread_mutex_unlock(&pglobal->in[id].db);
+        return;
+    }
+
+    memcpy(pglobal->in[id].buf, jpegData, jpegSize);
+    pglobal->in[id].size = (int)jpegSize;
+
+    struct timeval ts;
+    gettimeofday(&ts, NULL);
+    pglobal->in[id].timestamp = ts;
+
     pthread_cond_broadcast(&pglobal->in[id].db_update);
     pthread_mutex_unlock(&pglobal->in[id].db);
 }
 
-// ── BufferReceived ───────────────────────────────────────────────────────────
-void
-MjpgConsumer::BufferReceived(BBuffer *buffer)
-{
-    if (!fCtx->running || !fConnected) {
-        buffer->Recycle();
-        return;
+// ══════════════════════════════════════════════════════════════════════════════
+// MjpgLooper: receives MSG_WEBCAM_FRAME from WebcamDevice::StartCapture()
+// ══════════════════════════════════════════════════════════════════════════════
+class MjpgLooper : public BLooper {
+public:
+    MjpgLooper(int id)
+        : BLooper("mjpg_webcam_capture"), fId(id)
+    {
     }
 
-    uint8 *data = (uint8 *)buffer->Data();
-    int    w    = fCtx->width;
-    int    h    = fCtx->height;
+    virtual void MessageReceived(BMessage *message)
+    {
+        if (message->what != MSG_WEBCAM_FRAME) {
+            BLooper::MessageReceived(message);
+            return;
+        }
 
-    if (data && w > 0 && h > 0)
-        EncodeAndPublish(data, w, h);
+        BBitmap *bitmap = NULL;
+        if (message->FindPointer("bitmap", (void **)&bitmap) != B_OK)
+            return;
 
-    buffer->Recycle();
-}
+        if (bitmap == NULL)
+            return;
+
+        if (bitmap->IsValid())
+            EncodeAndPublish(fId, bitmap);
+        else
+            delete bitmap;
+    }
+
+private:
+    int fId;
+};
 
 // ══════════════════════════════════════════════════════════════════════════════
-// Setup thread: find producer node, create consumer, connect, start
+// Setup thread: enumerate device, start capture, run until stopped
 // ══════════════════════════════════════════════════════════════════════════════
 static int32
 setup_thread_func(void *arg)
 {
     plugin_ctx *c = (plugin_ctx *)arg;
 
-    /* Media Kit requires be_app; create a minimal one if missing */
     if (be_app == NULL)
         gApp = new BApplication("application/x-vnd.mjpg-haiku-input");
 
-    BMediaRoster *roster = BMediaRoster::Roster();
-    if (!roster) {
-        LOG("Failed to get BMediaRoster");
+    WebcamRoster *roster = new WebcamRoster();
+    roster->EnumerateDevices();
+
+    if (roster->CountDevices() == 0) {
+        LOG("No webcams found");
+        delete roster;
         return B_ERROR;
     }
 
-    /* find live video producer nodes */
-    live_node_info nodes[16];
-    int32          count = 16;
-    media_format   filter;
-    memset(&filter, 0, sizeof(filter));
-    filter.type = B_MEDIA_RAW_VIDEO;
+    WebcamDevice *device = NULL;
+    if (c->node_name[0] != '\0')
+        device = roster->DeviceByName(c->node_name);
+    if (device == NULL)
+        device = roster->DeviceAt(0);
 
-    status_t err = roster->GetLiveNodes(nodes, &count,
-                                        &filter, NULL, NULL,
-                                        B_BUFFER_PRODUCER | B_PHYSICAL_INPUT);
-    if (err != B_OK || count == 0) {
-        LOG("No live video producer found (err=%s, count=%d)",
-            strerror(err), (int)count);
-        return B_ERROR;
-    }
+    LOG("Using device '%s'", device->Name());
 
-    /* pick node: first match (or by name if specified) */
-    int chosen = 0;
-    if (c->node_name[0] != '\0') {
-        for (int i = 0; i < count; i++) {
-            if (strstr(nodes[i].name, c->node_name)) {
-                chosen = i;
-                break;
-            }
-        }
-    }
-    c->producer_node = nodes[chosen].node;
-    LOG("Using producer: '%s' (id=%d)", nodes[chosen].name,
-        (int)c->producer_node.node);
+    MjpgLooper *looper = new MjpgLooper(c->id);
+    looper->Run();
 
-    /* create and register our consumer */
-    gConsumer = new MjpgConsumer(c);
-    err = roster->RegisterNode(gConsumer);
+    status_t err = device->StartCapture(looper);
     if (err != B_OK) {
-        LOG("RegisterNode failed: %s", strerror(err));
+        LOG("StartCapture failed: %s", strerror(err));
+        looper->Lock();
+        looper->Quit();
+        delete roster;
         return B_ERROR;
     }
 
-    /* get free outputs from producer */
-    media_output outputs[8];
-    int32        nout = 8;
-    err = roster->GetFreeOutputsFor(c->producer_node,
-                                    outputs, nout, &nout,
-                                    B_MEDIA_RAW_VIDEO);
-    if (err != B_OK || nout == 0) {
-        LOG("No free outputs on producer: %s", strerror(err));
-        roster->UnregisterNode(gConsumer);
-        return B_ERROR;
-    }
-    c->prod_out = outputs[0];
+    LOG("Capture started");
 
-    /* request B_RGB32 at the configured resolution */
-    media_format connFmt;
-    memset(&connFmt, 0, sizeof(connFmt));
-    connFmt.type                         = B_MEDIA_RAW_VIDEO;
-    connFmt.u.raw_video.display.format   = B_RGB32;
-    connFmt.u.raw_video.display.line_width  = (uint32)c->width;
-    connFmt.u.raw_video.display.line_count  = (uint32)c->height;
+    while (!pglobal->stop && c->running)
+        snooze(200000);
 
-    err = roster->Connect(c->prod_out.source,
-                          gConsumer->Input().destination,
-                          &connFmt,
-                          &c->prod_out, &c->cons_in);
-    if (err != B_OK) {
-        LOG("Connect failed: %s", strerror(err));
-        roster->UnregisterNode(gConsumer);
-        return B_ERROR;
-    }
-    c->connected = true;
-    LOG("Connection established: %dx%d", c->width, c->height);
+    LOG("Stopping capture");
+    device->StopCapture();
+    looper->Lock();
+    looper->Quit();
+    delete roster;
 
-    /* start consumer event loop BEFORE the producer sends buffers */
-    gConsumer->StartLooper();
-
-    bigtime_t latency = 0;
-    roster->GetLatencyFor(c->producer_node, &latency);
-    bigtime_t startTime = system_time() + latency + 50000LL;
-
-    roster->StartNode(gConsumer->Node(), startTime);
-    roster->StartNode(c->producer_node, startTime);
-    LOG("Nodes started");
-
-    /* keep this thread alive until input_stop() sets running = false */
-    while (c->running)
-        snooze(100000LL); /* 100 ms */
-
-    /* ── teardown ── */
-    roster->StopNode(c->producer_node, system_time(), true /* sync */);
-    roster->StopNode(gConsumer->Node(), system_time(), true);
-    roster->Disconnect(c->prod_out, c->cons_in);
-    c->connected = false;
-
-    roster->UnregisterNode(gConsumer);
-    gConsumer->StopLooper();
-    gConsumer = NULL;
-
-    LOG("Setup thread exiting");
     return B_OK;
 }
 
 // ══════════════════════════════════════════════════════════════════════════════
-// mjpg-streamer C plugin interface
+// mjpg-streamer plugin interface
 // ══════════════════════════════════════════════════════════════════════════════
-extern "C" {
-
-int input_init(input_parameter *param, int id)
+extern "C" int
+input_init(input_parameter *param, int id)
 {
-    pglobal = param->global;
+    gCtx.id          = id;
+    gCtx.node_name[0]= '\0';
+    gCtx.running     = false;
 
-    ctx = new plugin_ctx();
-    memset(ctx, 0, sizeof(*ctx));
-    ctx->id      = id;
-    ctx->width   = 320;
-    ctx->height  = 240;
-    ctx->running = false;
+    param->argv[0] = (char *)PLUGIN_NAME;
 
-    /* parse plugin arguments */
-    for (int i = 1; i < param->argc; i++) {
-        if (strcmp(param->argv[i], "-r") == 0 && i + 1 < param->argc) {
-            int w = 0, h = 0;
-            if (sscanf(param->argv[++i], "%dx%d", &w, &h) == 2 &&
-                w > 0 && h > 0) {
-                ctx->width  = w;
-                ctx->height = h;
-            }
-        } else if (strcmp(param->argv[i], "-d") == 0 && i + 1 < param->argc) {
-            strlcpy(ctx->node_name, param->argv[++i], sizeof(ctx->node_name));
+    reset_getopt();
+    while (1) {
+        int option_index = 0, c = 0;
+        static struct option long_options[] = {
+            {"h",    no_argument,       0, 0},
+            {"help", no_argument,       0, 0},
+            {"d",    required_argument, 0, 0},
+            {0, 0, 0, 0}
+        };
+
+        c = getopt_long_only(param->argc, param->argv, "", long_options, &option_index);
+        if (c == -1)
+            break;
+
+        if (c == '?') {
+            LOG("Usage: mjpg_streamer -i \"input_haiku_media.so [-d node_name]\"");
+            return 1;
+        }
+
+        switch (option_index) {
+        case 0:
+        case 1:
+            LOG("Usage: mjpg_streamer -i \"input_haiku_media.so [-d node_name]\"");
+            return 1;
+
+        case 2:
+            strlcpy(gCtx.node_name, optarg, sizeof(gCtx.node_name));
+            break;
+
+        default:
+            break;
         }
     }
 
-    /* allocate placeholder frame buffer */
-    pglobal->in[id].buf = (unsigned char *)malloc(
-        (size_t)(ctx->width * ctx->height * 4));
-    if (!pglobal->in[id].buf) {
-        LOG("malloc failed");
-        delete ctx; ctx = NULL;
-        return 1;
-    }
-    pglobal->in[id].size = 0;
+    pglobal = param->global;
+    pglobal->in[id].name = strdup(PLUGIN_NAME);
 
-    LOG("init OK  resolution=%dx%d  node_filter='%s'",
-        ctx->width, ctx->height, ctx->node_name);
+    LOG("init OK  node_filter='%s'", gCtx.node_name);
+
     return 0;
 }
 
-int input_run(int id)
+extern "C" int
+input_run(int id)
 {
-    ctx->running = true;
-    ctx->setup_tid = spawn_thread(setup_thread_func,
-                                  "haiku-media-setup",
-                                  B_NORMAL_PRIORITY,
-                                  ctx);
-    if (ctx->setup_tid < B_OK) {
-        LOG("spawn_thread failed");
-        ctx->running = false;
+    pglobal->in[id].buf = NULL;
+    gCtx.running = true;
+
+    gCtx.setup_tid = spawn_thread(setup_thread_func, "haiku_media_setup",
+                                   B_NORMAL_PRIORITY, &gCtx);
+    if (gCtx.setup_tid < 0) {
+        LOG("spawn_thread failed: %s", strerror(gCtx.setup_tid));
         return 1;
     }
-    resume_thread(ctx->setup_tid);
+    resume_thread(gCtx.setup_tid);
+
     LOG("run OK");
     return 0;
 }
 
-int input_stop(int id)
+extern "C" int
+input_stop(int id)
 {
-    LOG("stopping...");
-    ctx->running = false;
-    int32 ret = 0;
-    wait_for_thread(ctx->setup_tid, &ret);
-
-    free(pglobal->in[id].buf);
-    pglobal->in[id].buf  = NULL;
-    pglobal->in[id].size = 0;
-
-    delete ctx;
-    ctx = NULL;
-
-    if (gApp) {
-        delete gApp;
-        gApp = NULL;
-    }
-    LOG("stopped");
+    gCtx.running = false;
     return 0;
 }
-
-int input_cmd(int id, unsigned int cmd, unsigned int value)
-{
-    return 0;
-}
-
-} /* extern "C" */
 
 #endif /* __HAIKU__ */

--- a/mjpg-streamer-experimental/plugins/input_haiku_media/input_haiku_media.cpp
+++ b/mjpg-streamer-experimental/plugins/input_haiku_media/input_haiku_media.cpp
@@ -1,0 +1,473 @@
+/*
+ * input_haiku_media.cpp — mjpg-streamer input plugin using Haiku Media Kit
+ *
+ * Connects to a live video producer node (e.g. haiku-uvc-webcam add-on)
+ * via BMediaRoster, receives B_RGB32 frames, encodes to JPEG, and feeds
+ * them into mjpg-streamer's shared frame buffer.
+ *
+ * Build:  CMakeLists.txt in this directory (Haiku only)
+ * Usage:  mjpg_streamer -i "input_haiku_media.so [-r WxH] [-d node_name]"
+ *                        -o "output_http.so"
+ */
+
+#ifdef __HAIKU__
+
+// ── Haiku C++ headers ───────────────────────────────────────────────────────
+#include <Application.h>
+#include <Bitmap.h>
+#include <BitmapStream.h>
+#include <Buffer.h>
+#include <BufferConsumer.h>
+#include <DataIO.h>
+#include <MediaDefs.h>
+#include <MediaEventLooper.h>
+#include <MediaFormats.h>
+#include <MediaRoster.h>
+#include <OS.h>
+#include <TranslatorRoster.h>
+
+// ── C headers ───────────────────────────────────────────────────────────────
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
+#include <pthread.h>
+
+// ── mjpg-streamer interface ─────────────────────────────────────────────────
+// Include via root header to avoid double-include of plugins/input.h
+extern "C" {
+#include "mjpg_streamer.h"
+}
+
+// ── Plugin bookkeeping ──────────────────────────────────────────────────────
+#define PLUGIN_NAME "input_haiku_media"
+// Override the generic LOG macro with our prefixed version
+#undef LOG
+#define LOG(fmt, ...) \
+    fprintf(stderr, "[" PLUGIN_NAME "] " fmt "\n", ##__VA_ARGS__)
+
+static globals *pglobal = NULL;   /* set in input_init */
+
+// ── Shared plugin state ─────────────────────────────────────────────────────
+struct plugin_ctx {
+    int            id;
+    int            width;
+    int            height;
+    char           node_name[256]; /* optional: filter by name */
+    volatile bool  running;
+    thread_id      setup_tid;
+    /* filled by setup thread once connected */
+    media_node     producer_node;
+    media_output   prod_out;
+    media_input    cons_in;
+    bool           connected;
+};
+
+static plugin_ctx    *ctx       = NULL;
+static BApplication  *gApp      = NULL;  /* created if be_app is NULL */
+
+// forward declaration
+class MjpgConsumer;
+static MjpgConsumer  *gConsumer = NULL;
+
+// ══════════════════════════════════════════════════════════════════════════════
+// MjpgConsumer: BBufferConsumer + BMediaEventLooper
+// ══════════════════════════════════════════════════════════════════════════════
+class MjpgConsumer : public BBufferConsumer, public BMediaEventLooper {
+public:
+    explicit MjpgConsumer(plugin_ctx *c);
+    ~MjpgConsumer() override {}
+
+    /* BMediaNode */
+    BMediaAddOn *AddOn(int32 *) const override { return NULL; }
+
+    /* BBufferConsumer */
+    status_t AcceptFormat(const media_destination &dest,
+                          media_format *fmt) override;
+    status_t GetNextInput(int32 *cookie, media_input *out) override;
+    void     BufferReceived(BBuffer *buffer) override;
+    void     DisposeInputCookie(int32) override {}
+    void     ProducerDataStatus(const media_destination &,
+                                int32, bigtime_t) override {}
+    status_t GetLatencyFor(const media_destination &,
+                           bigtime_t *latency,
+                           media_node_id *) override
+    {
+        *latency = 5000LL; /* 5 ms */
+        return B_OK;
+    }
+    status_t Connected(const media_source &src,
+                       const media_destination &dest,
+                       const media_format &fmt,
+                       media_input *out_input) override;
+    void     Disconnected(const media_source &,
+                          const media_destination &) override;
+    status_t FormatChanged(const media_source &,
+                           const media_destination &,
+                           int32,
+                           const media_format &) override { return B_OK; }
+
+    /* BMediaEventLooper */
+    void HandleEvent(const media_timed_event *,
+                     bigtime_t, bool) override {}
+
+    media_input &Input() { return fInput; }
+
+    /* Public wrappers for protected Run()/Quit() */
+    void StartLooper() { Run(); }
+    void StopLooper()  { Quit(); }
+
+private:
+    void EncodeAndPublish(uint8 *rgb32, int w, int h);
+
+    plugin_ctx *fCtx;
+    media_input fInput;
+    bool        fConnected;
+};
+
+// ── Constructor ─────────────────────────────────────────────────────────────
+MjpgConsumer::MjpgConsumer(plugin_ctx *c)
+    : BMediaNode("mjpg-haiku-consumer"),
+      BBufferConsumer(B_MEDIA_RAW_VIDEO),
+      BMediaEventLooper(),
+      fCtx(c),
+      fConnected(false)
+{
+    fInput.destination.port = ControlPort();
+    fInput.destination.id   = 0;
+    fInput.node             = Node();
+    fInput.source           = media_source::null;
+    strlcpy(fInput.name, "Video In", sizeof(fInput.name));
+}
+
+// ── AcceptFormat ─────────────────────────────────────────────────────────────
+status_t
+MjpgConsumer::AcceptFormat(const media_destination &, media_format *fmt)
+{
+    if (fmt->type != B_MEDIA_RAW_VIDEO &&
+        fmt->type != B_MEDIA_UNKNOWN_TYPE)
+        return B_MEDIA_BAD_FORMAT;
+
+    fmt->type = B_MEDIA_RAW_VIDEO;
+    fmt->u.raw_video.display.format = B_RGB32;
+    return B_OK;
+}
+
+// ── GetNextInput ─────────────────────────────────────────────────────────────
+status_t
+MjpgConsumer::GetNextInput(int32 *cookie, media_input *out)
+{
+    if (*cookie != 0)
+        return B_BAD_INDEX;
+    *out = fInput;
+    (*cookie)++;
+    return B_OK;
+}
+
+// ── Connected ────────────────────────────────────────────────────────────────
+status_t
+MjpgConsumer::Connected(const media_source &src,
+                        const media_destination &,
+                        const media_format &fmt,
+                        media_input *out_input)
+{
+    fInput.source = src;
+    fInput.format = fmt;
+    *out_input    = fInput;
+    fConnected    = true;
+
+    /* update dimensions from negotiated format */
+    uint32 w = fmt.u.raw_video.display.line_width;
+    uint32 h = fmt.u.raw_video.display.line_count;
+    if (w > 0) fCtx->width  = (int)w;
+    if (h > 0) fCtx->height = (int)h;
+    LOG("Connected: %dx%d B_RGB32", fCtx->width, fCtx->height);
+    return B_OK;
+}
+
+// ── Disconnected ─────────────────────────────────────────────────────────────
+void
+MjpgConsumer::Disconnected(const media_source &, const media_destination &)
+{
+    fConnected    = false;
+    fInput.source = media_source::null;
+    LOG("Disconnected");
+}
+
+// ── EncodeAndPublish: B_RGB32 → JPEG → pglobal ──────────────────────────────
+void
+MjpgConsumer::EncodeAndPublish(uint8 *rgb32, int w, int h)
+{
+    /* Wrap raw pixels in a BBitmap (B_RGB32 = BGRA byte order on Haiku) */
+    BBitmap *bm = new BBitmap(BRect(0, 0, w - 1, h - 1), B_RGB32);
+    if (!bm || bm->InitCheck() != B_OK) {
+        delete bm;
+        return;
+    }
+    size_t sz = (size_t)(w * h * 4);
+    memcpy(bm->Bits(), rgb32, sz);
+
+    /* Encode to JPEG via the Translation Kit (JPEG Translator must be installed) */
+    BBitmapStream bs(bm);   /* bs takes ownership of bm */
+    BMallocIO     jpegBuf;
+
+    BTranslatorRoster *roster = BTranslatorRoster::Default();
+    status_t err = roster->Translate(&bs, NULL, NULL, &jpegBuf, B_JPEG_FORMAT);
+
+    /* detach so bs destructor doesn't double-free */
+    BBitmap *detached = NULL;
+    bs.DetachBitmap(&detached);
+    delete detached;
+
+    if (err != B_OK) {
+        LOG("JPEG translation error: %s", strerror(err));
+        return;
+    }
+
+    size_t  jpegSz   = jpegBuf.BufferLength();
+    uint8  *jpegData = (uint8 *)malloc(jpegSz);
+    if (!jpegData) return;
+    memcpy(jpegData, jpegBuf.Buffer(), jpegSz);
+
+    /* publish to mjpg-streamer */
+    int id = fCtx->id;
+    pthread_mutex_lock(&pglobal->in[id].db);
+    free(pglobal->in[id].buf);
+    pglobal->in[id].buf  = jpegData;
+    pglobal->in[id].size = (int)jpegSz;
+    gettimeofday(&pglobal->in[id].timestamp, NULL);
+    pthread_cond_broadcast(&pglobal->in[id].db_update);
+    pthread_mutex_unlock(&pglobal->in[id].db);
+}
+
+// ── BufferReceived ───────────────────────────────────────────────────────────
+void
+MjpgConsumer::BufferReceived(BBuffer *buffer)
+{
+    if (!fCtx->running || !fConnected) {
+        buffer->Recycle();
+        return;
+    }
+
+    uint8 *data = (uint8 *)buffer->Data();
+    int    w    = fCtx->width;
+    int    h    = fCtx->height;
+
+    if (data && w > 0 && h > 0)
+        EncodeAndPublish(data, w, h);
+
+    buffer->Recycle();
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// Setup thread: find producer node, create consumer, connect, start
+// ══════════════════════════════════════════════════════════════════════════════
+static int32
+setup_thread_func(void *arg)
+{
+    plugin_ctx *c = (plugin_ctx *)arg;
+
+    /* Media Kit requires be_app; create a minimal one if missing */
+    if (be_app == NULL)
+        gApp = new BApplication("application/x-vnd.mjpg-haiku-input");
+
+    BMediaRoster *roster = BMediaRoster::Roster();
+    if (!roster) {
+        LOG("Failed to get BMediaRoster");
+        return B_ERROR;
+    }
+
+    /* find live video producer nodes */
+    live_node_info nodes[16];
+    int32          count = 16;
+    media_format   filter;
+    memset(&filter, 0, sizeof(filter));
+    filter.type = B_MEDIA_RAW_VIDEO;
+
+    status_t err = roster->GetLiveNodes(nodes, &count,
+                                        &filter, NULL, NULL,
+                                        B_BUFFER_PRODUCER | B_PHYSICAL_INPUT);
+    if (err != B_OK || count == 0) {
+        LOG("No live video producer found (err=%s, count=%d)",
+            strerror(err), (int)count);
+        return B_ERROR;
+    }
+
+    /* pick node: first match (or by name if specified) */
+    int chosen = 0;
+    if (c->node_name[0] != '\0') {
+        for (int i = 0; i < count; i++) {
+            if (strstr(nodes[i].name, c->node_name)) {
+                chosen = i;
+                break;
+            }
+        }
+    }
+    c->producer_node = nodes[chosen].node;
+    LOG("Using producer: '%s' (id=%d)", nodes[chosen].name,
+        (int)c->producer_node.node);
+
+    /* create and register our consumer */
+    gConsumer = new MjpgConsumer(c);
+    err = roster->RegisterNode(gConsumer);
+    if (err != B_OK) {
+        LOG("RegisterNode failed: %s", strerror(err));
+        return B_ERROR;
+    }
+
+    /* get free outputs from producer */
+    media_output outputs[8];
+    int32        nout = 8;
+    err = roster->GetFreeOutputsFor(c->producer_node,
+                                    outputs, nout, &nout,
+                                    B_MEDIA_RAW_VIDEO);
+    if (err != B_OK || nout == 0) {
+        LOG("No free outputs on producer: %s", strerror(err));
+        roster->UnregisterNode(gConsumer);
+        return B_ERROR;
+    }
+    c->prod_out = outputs[0];
+
+    /* request B_RGB32 at the configured resolution */
+    media_format connFmt;
+    memset(&connFmt, 0, sizeof(connFmt));
+    connFmt.type                         = B_MEDIA_RAW_VIDEO;
+    connFmt.u.raw_video.display.format   = B_RGB32;
+    connFmt.u.raw_video.display.line_width  = (uint32)c->width;
+    connFmt.u.raw_video.display.line_count  = (uint32)c->height;
+
+    err = roster->Connect(c->prod_out.source,
+                          gConsumer->Input().destination,
+                          &connFmt,
+                          &c->prod_out, &c->cons_in);
+    if (err != B_OK) {
+        LOG("Connect failed: %s", strerror(err));
+        roster->UnregisterNode(gConsumer);
+        return B_ERROR;
+    }
+    c->connected = true;
+    LOG("Connection established: %dx%d", c->width, c->height);
+
+    /* start consumer event loop BEFORE the producer sends buffers */
+    gConsumer->StartLooper();
+
+    bigtime_t latency = 0;
+    roster->GetLatencyFor(c->producer_node, &latency);
+    bigtime_t startTime = system_time() + latency + 50000LL;
+
+    roster->StartNode(gConsumer->Node(), startTime);
+    roster->StartNode(c->producer_node, startTime);
+    LOG("Nodes started");
+
+    /* keep this thread alive until input_stop() sets running = false */
+    while (c->running)
+        snooze(100000LL); /* 100 ms */
+
+    /* ── teardown ── */
+    roster->StopNode(c->producer_node, system_time(), true /* sync */);
+    roster->StopNode(gConsumer->Node(), system_time(), true);
+    roster->Disconnect(c->prod_out, c->cons_in);
+    c->connected = false;
+
+    roster->UnregisterNode(gConsumer);
+    gConsumer->StopLooper();
+    gConsumer = NULL;
+
+    LOG("Setup thread exiting");
+    return B_OK;
+}
+
+// ══════════════════════════════════════════════════════════════════════════════
+// mjpg-streamer C plugin interface
+// ══════════════════════════════════════════════════════════════════════════════
+extern "C" {
+
+int input_init(input_parameter *param, int id)
+{
+    pglobal = param->global;
+
+    ctx = new plugin_ctx();
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->id      = id;
+    ctx->width   = 320;
+    ctx->height  = 240;
+    ctx->running = false;
+
+    /* parse plugin arguments */
+    for (int i = 1; i < param->argc; i++) {
+        if (strcmp(param->argv[i], "-r") == 0 && i + 1 < param->argc) {
+            int w = 0, h = 0;
+            if (sscanf(param->argv[++i], "%dx%d", &w, &h) == 2 &&
+                w > 0 && h > 0) {
+                ctx->width  = w;
+                ctx->height = h;
+            }
+        } else if (strcmp(param->argv[i], "-d") == 0 && i + 1 < param->argc) {
+            strlcpy(ctx->node_name, param->argv[++i], sizeof(ctx->node_name));
+        }
+    }
+
+    /* allocate placeholder frame buffer */
+    pglobal->in[id].buf = (unsigned char *)malloc(
+        (size_t)(ctx->width * ctx->height * 4));
+    if (!pglobal->in[id].buf) {
+        LOG("malloc failed");
+        delete ctx; ctx = NULL;
+        return 1;
+    }
+    pglobal->in[id].size = 0;
+
+    LOG("init OK  resolution=%dx%d  node_filter='%s'",
+        ctx->width, ctx->height, ctx->node_name);
+    return 0;
+}
+
+int input_run(int id)
+{
+    ctx->running = true;
+    ctx->setup_tid = spawn_thread(setup_thread_func,
+                                  "haiku-media-setup",
+                                  B_NORMAL_PRIORITY,
+                                  ctx);
+    if (ctx->setup_tid < B_OK) {
+        LOG("spawn_thread failed");
+        ctx->running = false;
+        return 1;
+    }
+    resume_thread(ctx->setup_tid);
+    LOG("run OK");
+    return 0;
+}
+
+int input_stop(int id)
+{
+    LOG("stopping...");
+    ctx->running = false;
+    int32 ret = 0;
+    wait_for_thread(ctx->setup_tid, &ret);
+
+    free(pglobal->in[id].buf);
+    pglobal->in[id].buf  = NULL;
+    pglobal->in[id].size = 0;
+
+    delete ctx;
+    ctx = NULL;
+
+    if (gApp) {
+        delete gApp;
+        gApp = NULL;
+    }
+    LOG("stopped");
+    return 0;
+}
+
+int input_cmd(int id, unsigned int cmd, unsigned int value)
+{
+    return 0;
+}
+
+} /* extern "C" */
+
+#endif /* __HAIKU__ */

--- a/mjpg-streamer-experimental/plugins/output_http/httpd.c
+++ b/mjpg-streamer-experimental/plugins/output_http/httpd.c
@@ -707,9 +707,11 @@ void send_file(int id, int fd, char *parameter)
     int i, lfd;
     config conf = servers[id].conf;
 
-    /* in case no parameter was given */
-    if(parameter == NULL || strlen(parameter) == 0)
-        parameter = "index.html";
+    /* return 404 for root access */
+    if(parameter == NULL || strlen(parameter) == 0) {
+        send_error(fd, 404, "Not Found");
+        return;
+    }
 
     /* find file-extension */
     char * pch;
@@ -726,6 +728,14 @@ void send_file(int id, int fd, char *parameter)
     } else {
         extension = parameter + lastDot;
         DBG("%s EXTENSION: %s\n", parameter, extension);
+    }
+
+    /* Restrict only HTML pages, keep other assets (js/css/images) accessible. */
+    if((strcmp(extension, ".htm") == 0 || strcmp(extension, ".html") == 0) &&
+       strcmp(parameter, "control.htm") != 0 &&
+       strcmp(parameter, "control_ja.htm") != 0) {
+        send_error(fd, 404, "Only control.htm and control_ja.htm are available");
+        return;
     }
 
     /* determine mime-type */

--- a/mjpg-streamer-experimental/utils.c
+++ b/mjpg-streamer-experimental/utils.c
@@ -26,10 +26,10 @@
 #include <linux/types.h>
 #include <string.h>
 #include <fcntl.h>
-#include <wait.h>
+#include <sys/wait.h>
 #include <time.h>
 #include <limits.h>
-#include <linux/stat.h>
+// #include <linux/stat.h> -- not needed, sys/stat.h covers this
 #include <sys/stat.h>
 
 #include "utils.h"

--- a/mjpg-streamer-experimental/www/control_ja.htm
+++ b/mjpg-streamer-experimental/www/control_ja.htm
@@ -1,0 +1,292 @@
+<html style="overflow-y: auto;">
+  <head>
+    <script type="text/javascript" src="jquery.js"></script>
+    
+	<link type="text/css" href="jquery.ui.custom.css" rel="stylesheet" />
+    <script type="text/javascript" src="jquery.ui.core.min.js"></script>    
+    <script type="text/javascript" src="jquery.ui.widget.min.js"></script>    
+    <script type="text/javascript" src="jquery.ui.tabs.min.js"></script>    
+            
+    <link type="text/css" rel="stylesheet" href="JQuerySpinBtn.css" />
+    <script type="text/javascript" src="JQuerySpinBtn.js"></script>    
+    
+	<script type="text/javascript">
+	$(function() {
+		$("#tabs").tabs();
+	});
+	
+	$(document).ready(function() {
+		//top.resizeTo($(window).width(), $(document).height() + (top.outerHeight - $(window).height()));
+	});
+	</script>
+
+  </head>
+  <body style="overflow-y: auto;">
+    <script type="text/javascript"> 
+        // 翻訳用の辞書
+        const translations = {
+            // タイトルの翻訳
+            "User Controls": "ユーザーコントロール",
+            "Camera Controls": "カメラコントロール",
+            // コントロール名の翻訳
+            "Brightness": "明るさ",
+            "Contrast": "コントラスト",
+            "Saturation": "彩度",
+            "Hue": "色相",
+            "White Balance, Automatic": "ホワイトバランス（自動）",
+            "Gamma": "ガンマ",
+            "Gain": "ゲイン",
+            "Power Line Frequency": "電源周波数",
+            "White Balance Temperature": "ホワイトバランス温度",
+            "Sharpness": "シャープネス",
+            "Backlight Compensation": "逆光補正",
+            "Auto Exposure": "自動露出",
+            "Exposure Time, Absolute": "露出時間（絶対値）",
+            "Exposure, Dynamic Framerate": "露出、動的フレームレート",
+            "Pan, Absolute": "パン（絶対値）",
+            "Tilt, Absolute": "チルト（絶対値）",
+            "Focus, Absolute": "フォーカス（絶対値）",
+            "Focus, Automatic Continuous": "フォーカス（自動）",
+            "Zoom, Absolute": "ズーム（絶対値）",
+            "JPEG quality": "JPEG品質",
+            
+            // メニュー選択肢の翻訳
+            "Disabled": "無効",
+            "Enabled": "有効",
+            "Manual Mode": "手動モード",
+            "Auto Mode": "自動モード",
+            "Shutter Priority Mode": "シャッター優先モード",
+            "Aperture Priority Mode": "絞り優先モード",
+            "50 Hz": "50 Hz",
+            "60 Hz": "60 Hz",
+            "Off": "オフ",
+            "On": "オン"
+        };
+        
+        // 翻訳関数
+        function translate(text) {
+            return translations[text] || text;
+        }
+        		
+		function setControl(dest, plugin, id, group, value) {
+          $.get('./?action=command&dest=' +		dest +
+          						'&plugin=' +	plugin+
+          						'&id='+ 		id + 
+          						'&group='+ 		group + 
+          						'&value=' +		value );
+        }
+
+        function setControl_bool(dest, plugin, id, group, value) {
+          if (value == false)
+            setControl(dest, plugin, id, group, 0);
+          else
+            setControl(dest, plugin, id, group, 1);
+        }
+
+        function setControl_string(dest, plugin, id, group, value) {
+          if (value.length < minlength) {
+            alert("The input string has to be least"+minlength+" characters!");
+            return;
+          }
+          $.get('./?action=command&dest=' +		dest +
+          						'&plugin=' +	plugin+
+          						'&id='+ 		id + 
+          						'&group='+ 		group + 
+          						'&value=' +		value , 
+			function(data){
+             alert("Data Loaded: " + data);
+           });
+        }
+                        
+        function setResolution(plugin, controlId, group, value) {
+	        $.get('./?action=command&dest=0'	+		// resolution command always goes to the input plugin
+					'&plugin=' +	plugin+
+					'&id'+ 			controlId + 
+					'&group=1'	+					// IN_CMD_RESOLUTION == 1,		
+					'&value=' +		value, 
+				function(data){
+				     if (data == 0) {
+				     	$("#statustd").text("Success");
+				     } else {
+				     	$("#statustd").text("Error: " + data);
+				     }
+		        }
+	        );
+        }
+                
+        function addControl(plugin_id, suffix) {
+        var dest = suffix=="in"?0:1;
+        $.getJSON(suffix+"put_"+plugin_id+".json",
+          function(data) {
+            $.each(data.controls, function(i,item){
+              $('<tr/>').attr("id", "tr_"+suffix+"_"+plugin_id+"_"+item.group+"_"+item.id).appendTo("#controltable_"+suffix+"-"+plugin_id);
+              // BUTTON type controls does not have a label 
+              if (item.type == 4) {
+                $("<td/>").appendTo("#tr-"+item.id);
+              } else {
+                if (item.type == 6) { // Class type controls
+                  $("<td/>").text(translate(item.name)).attr("style", "font-weight:bold;").appendTo("#tr_"+suffix+"_"+plugin_id+"_"+item.group+"_"+item.id);
+                  return;
+                } else {
+                  $("<td/>").text(translate(item.name)).appendTo("#tr_"+suffix+"_"+plugin_id+"_"+item.group+"_"+item.id);
+                }
+              }
+
+              $("<td/>").attr("id", "td_ctrl_"+suffix+"_"+plugin_id+"_"+item.group+"-"+item.id)
+              	.appendTo("#tr_"+suffix+"_"+plugin_id+"_"+item.group+"_"+item.id);
+              if((item.type == 1) || (item.type == 5)) { // integer type controls
+                if ((item.id == 10094852) && (item.group == 1) && (item.dest == 0)) { //V4L2_CID_PAN_RELATIVE
+				  $("<button/>")
+                  .attr("type", "button")
+                  .attr("style", "width: 50%; height: 100%;")
+                  .text("<")
+                  .click(function(){setControl(dest, plugin_id, item.id, item.group, 200);})
+                  .appendTo("#td_ctrl_"+suffix+"_"+plugin_id+"_"+item.group+"-"+item.id);
+                  $("<button/>")
+                  .attr("type", "button")
+                  .attr("style", "width: 50%; height: 100%;")
+                  .text(">")
+                  .click(function(){setControl(dest, plugin_id, item.id, item.group, -200);})
+                  .appendTo("#td_ctrl_"+suffix+"_"+plugin_id+"_"+item.group+"-"+item.id);
+                } else if ((item.id == 10094853) && 
+                		   (item.group == 1) && 
+                		   (item.dest == 0)){ // V4L2_CID_TILT_RELATIVE
+        		   $("<button/>")
+                  .attr("type", "button")
+                  .attr("style", "width: 50%; height: 100%;")
+                  .text("^")
+                  .click(function(){setControl(dest, plugin_id, item.id, item.group, -200);})
+                  .appendTo("#td_ctrl_"+suffix+"_"+plugin_id+"_"+item.group+"-"+item.id);
+                  $("<button/>")
+                  .attr("type", "button")
+                  .attr("style", "width: 50%; height: 100%;")
+                  .text("ˇ")
+                  .click(function(){setControl(dest, plugin_id, item.id, item.group, 200);})
+                  .appendTo("#td_ctrl_"+suffix+"_"+plugin_id+"_"+item.group+"-"+item.id);
+                } else { // another non spec control
+                    var options = {min: item.min, max: item.max, step: item.step,}
+		            $("<input/>")
+		              .attr("value", item.value)
+		              .attr("id", "spinbox-"+item.id)
+		              .SpinButton(options)
+		              .bind("valueChanged", function() {setControl(dest, plugin_id, item.id, item.group, $(this).val());})
+		              .appendTo("#td_ctrl_"+suffix+"_"+plugin_id+"_"+item.group+"-"+item.id);
+                } 
+              } else if (item.type == 2) { // boolean type controls
+                if (item.value == "1")
+                  $("<input/>")
+                    .attr("type", "checkbox")
+                    .attr("checked", "checked")
+                    .change(function(){setControl_bool(dest, plugin_id, item.id, item.group, ($(this).attr("checked")?1:0));})
+		            .appendTo("#td_ctrl_"+suffix+"_"+plugin_id+"_"+item.group+"-"+item.id);
+                else
+                  $("<input/>")
+                    .attr("type", "checkbox")
+                    .change(function(){setControl_bool(dest, plugin_id, item.id, item.group, ($(this).attr("checked")?1:0));})
+                    .appendTo("#td_ctrl_"+suffix+"_"+plugin_id+"_"+item.group+"-"+item.id);
+              } else if (item.type == 7) { // string type controls
+                  $("<input/>").attr("value", item.value).appendTo("#td_ctrl_"+suffix+"_"+plugin_id+"_"+item.group+"-"+item.id);
+              } else if (item.type == 3) { // menu
+                $("<select/>")
+                  .attr("name", "select-"+item.id)
+                  .attr("id", "menu-"+item.id)
+                  .attr("style", "width: 100%;")
+                  .change(function(){setControl(dest, plugin_id, item.id, item.group, $(this).val());})
+                  .appendTo("#td_ctrl_"+suffix+"_"+plugin_id+"_"+item.group+"-"+item.id);
+                $.each(item.menu, function(val, text) {
+                    const translatedText = translate(text);
+                    if (item.value == val) {
+                      $("#menu-"+item.id).append($('<option></option>').attr("selected", "selected").val(val).html(translatedText));
+                    } else {
+                      $("#menu-"+item.id).append($('<option></option>').val(val).html(translatedText));
+                    }
+                });
+              } else if (item.type == 4) { // button type
+                $("<button/>")
+                  .attr("type", "button")
+                  .attr("style", "width: 100%; height: 100%;")
+                  .text(translate(item.name))
+                  .click(function(){setControl(dest, plugin_id, item.id, item.group, 0);})
+                  .appendTo("#td_ctrl_"+suffix+"_"+plugin_id+"_"+item.group+"-"+item.id);
+              } else if (item.type == 7) { // string  type
+                $("<input/>")
+                    .attr("type", "text")
+                    .attr("maxlength", item.max)
+                    .change(function(){setControl_string(dest, plugin_id, item.id, item.group, $(this).text());})
+                    .appendTo("#td_ctrl_"+suffix+"_"+plugin_id+"_"+item.group+"-"+item.id);
+              } else {
+                 alert("Unknown control type: "+item.type);
+              }
+            });
+          }
+        );
+        }
+
+	    $.getJSON("program.json", 
+	    	function(data) {
+	    		$.each(data.inputs, 
+	    			function(i,input){
+		        		$("<li/>").attr("id", "li_in-"+input.id).appendTo("#ul_tabs");
+						$("<a/>").attr("href", "#controldiv_in-"+input.id)
+							.text(translate(input.name)).appendTo("#li_in-"+input.id);
+						$("<div/>").attr("id", "controldiv_in-"+input.id).appendTo("#tabs");
+						$("<table/>").attr("id", "controltable_in-"+input.id).appendTo("#controldiv_in-"+input.id);
+		    		}
+	    		)
+	    		
+	    		$.each(data.outputs, 
+	    			function(i,output){
+		        		$("<li/>").attr("id", "li_out-"+output.id).appendTo("#ul_tabs");
+						$("<a/>").attr("href", "#controldiv_out-"+output.id)
+							.text(translate(output.name)).appendTo("#li_out-"+output.id);
+						$("<div/>").attr("id", "controldiv_out-"+output.id).appendTo("#tabs");
+						$("<table/>").attr("id", "controltable_out-"+output.id).appendTo("#controldiv_out-"+output.id);
+		    		}
+	    		)
+	    	
+	    		$.each(data.inputs, 
+	    			function(i,input){
+	    				addControl(input.id, "in");
+		    		}
+	    		)
+	    		
+	    		$.each(data.outputs, 
+	    			function(i,output){
+	    				addControl(output.id, "out");
+		    		}
+	    		)
+	    		
+	    		$( "#tabs" ).tabs();
+	    	}
+	    );
+
+       $(function() {
+			
+		});
+        /*$.getJSON("input.json",
+          function(data) {
+          	$.each(data.formats, function(i,item){
+          	  if (item.current == "true") {
+          	  $("<select/>")
+                  .attr("id", "select-resolution")
+                  .attr("style", "width: 100%;")
+                  .change(function(){setResolution($(this).val());})
+                  .appendTo("#resolutions");
+           	    $.each(item.resolutions, function(val,res){
+           	    	if (item.currentResolution == val) {
+                      $("#select-resolution").append($('<option></option>').attr("selected", "selected").val(val).html(res));
+                    } else {
+                      $("#select-resolution").append($('<option></option>').val(val).html(res));
+                    }
+           	    });
+          	  }
+          	});
+          });*/
+    </script>
+    
+    <div id="tabs">
+		<ul id="ul_tabs"></ul>
+  	</div>
+
+  </body>
+</html>

--- a/mjpg-streamer-experimental/www/control_ja.htm
+++ b/mjpg-streamer-experimental/www/control_ja.htm
@@ -1,5 +1,6 @@
 <html style="overflow-y: auto;">
   <head>
+    <meta charset="UTF-8">
     <script type="text/javascript" src="jquery.js"></script>
     
 	<link type="text/css" href="jquery.ui.custom.css" rel="stylesheet" />

--- a/mjpg-streamer-experimental/www/index.html
+++ b/mjpg-streamer-experimental/www/index.html
@@ -23,6 +23,7 @@
         <a href="javascript.html">Javascript</a>
         <a href="videolan.html">VideoLAN</a>
         <a target="_blank" onClick="window.open(this.href, '_blank'); return false;" href="control.htm">Control</a>
+        <a target="_blank" onClick="window.open(this.href, '_blank'); return false;" href="control_ja.htm">コントロール</a>
       </div>
 
       <h3>Version info:</h3>


### PR DESCRIPTION
## Summary
- Adds `input_haiku_media`, a new mjpg-streamer input plugin for Haiku OS, since the existing `input_uvc` plugin depends on Linux's V4L2 API and cannot work on Haiku.
- Adds baseline Haiku buildability: a `compat/linux/{types.h,version.h,videodev2.h}` shim (mjpg_streamer.h currently includes these Linux headers unconditionally) and the CMakeLists.txt / utils.c changes needed to build on a non-Linux `CMAKE_SYSTEM_NAME`.
- The plugin bridges to [BubiCam](https://github.com/atomozero/BubiCam)'s `WebcamKit` library (`libwebcam.so`) rather than driving Haiku's Media Kit (`BMediaRoster`) directly. An earlier version that talked to the Media Kit directly reliably triggered kernel panics on the test VM during the node connect handshake (most likely missing `BMediaEventLooper` plumbing - no `NodeRegistered()`/`Run()`, so the node's own control thread never started). WebcamKit already implements that connection pipeline correctly and has been exercised extensively without a crash, so the plugin now just calls `WebcamRoster::EnumerateDevices()` + `WebcamDevice::StartCapture()` and JPEG-encodes the resulting `BBitmap` frames into mjpg-streamer's shared buffer.
- Also updates `output_http/httpd.c` (see diff) and adds a plugin `README.md` documenting the build requirement (a sibling `BubiCam` checkout providing `libwebcam.so`) and usage.
- All Haiku-specific changes are guarded by `#ifdef __HAIKU__` / `if(CMAKE_SYSTEM_NAME STREQUAL "Haiku")` / `if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")`, so Linux builds are unaffected.

## Test plan
- [x] Builds cleanly on Haiku (`cmake .. && make input_haiku_media`)
- [x] `./mjpg_streamer -i "./plugins/input_haiku_media/input_haiku_media.so" -o "./plugins/output_http/output_http.so -p 8090"` starts capture without crashing
- [x] `http://<haiku-ip>:8090/?action=snapshot` returns a real JPEG frame from a Logitech C270 webcam
- [ ] Not yet tested with other UVC webcams

Note: captured frames currently show tearing/corruption from a known USB isochronous-bandwidth limitation in the underlying UVC driver, unrelated to this plugin.
